### PR TITLE
Updates JSONAPI::Resources to 0.8.0; Removes piped_ruby dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Simple yet powerful way to get your Rails API compliant with [JSON API](http://j
 * [How does it work?](#how-does-it-work)
 * [Usage](#usage)
   * [Response](#response)
-    * [Rendes](#renders)
+    * [Renders](#renders)
     * [Formatters](#formatters)
   * [Request](#request)
     * [Params helpers](#params-helpers)
@@ -139,7 +139,7 @@ It takes arguments and generates a JSON API-compliant error response.
 ```
 
 Arguments:
-  - Exception 
+  - Exception
   - `json`: object to be rendered as a JSON document: ActiveRecord, Exception, Array of Hashes or any object which implements the `errors` method;
   - `status`: HTTP status code (Integer or Symbol). If ommited a status code will be automatically infered from the error body.
 
@@ -759,7 +759,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/jsonapi-utils. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](contributor-covenant.org) code of conduct.
+Bug reports and pull requests are welcome on GitHub at https://github.com/tiagopog/jsonapi-utils. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](https://contributor-covenant.org) code of conduct.
 
 
 ## License

--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,8 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.8.0.beta2'
-  spec.add_runtime_dependency 'piped_ruby', '0.2.1'
+  spec.add_runtime_dependency 'jsonapi-resources', '~> 0.8.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/jsonapi/utils.rb
+++ b/lib/jsonapi/utils.rb
@@ -4,7 +4,6 @@ require 'jsonapi/utils/exceptions'
 require 'jsonapi/utils/request'
 require 'jsonapi/utils/response'
 require 'jsonapi/utils/support/filter/custom'
-require 'piped_ruby'
 
 JSONAPI::Resource.extend JSONAPI::Utils::Support::Filter::Custom
 

--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -57,11 +57,10 @@ module JSONAPI
         end
 
         def build_collection(records, options = {})
-          -> { apply_filter(records, options) }
-            .>> { |filtered| apply_pagination(filtered, options) }
-            .>> { |paginated| apply_sort(paginated) }
-            .>> { |result| result.map { |record| turn_into_resource(record, options) } }
-            .unwrap
+          records = apply_filter(records, options)
+          records = apply_pagination(records, options)
+          records = apply_sort(records)
+          records.respond_to?(:to_ary) ? records.map { |record| turn_into_resource(record, options) } : []
         end
 
         def turn_into_resource(record, options = {})


### PR DESCRIPTION
Closes #33 (see the issue for additional discussion)

This PR:
* Removes the runtime dependency for piped_ruby, and simply reverts the piped ruby code back to its original.
* Updates JSONAPI::Resources to 0.8.0 (final)
* Fixes some readme spelling errors and broken links
  
Regarding piped ruby, I agree with @tiagopog that the reverted section (where piped ruby was implemented) is somewhat ugly and could/should be refactored, but I don't think we should introduce an unneeded dependency between the beta and final version.  Let's get it up to a full release using the new release of JSONAPI::Resources and then look at options for refactoring that method.

Additionally, I do not have code in this PR that changes version of the gem, as I don't know what your versioning/PR process is.  Please feel free to change whatever you need, and I'll be happy to help with discussing piped ruby, refactoring, etc as this gem moves forward! 