### PR TITLE
Add support for custom paginators

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Simple yet powerful way to get your Rails API compliant with [JSON API](http://j
   * [Response](#response)
     * [Renders](#renders)
     * [Formatters](#formatters)
+    * [Paginators](#paginators)
   * [Request](#request)
     * [Params helpers](#params-helpers)
 * [Full example](#full-example)
@@ -175,6 +176,28 @@ end
 Arguments:
   - First: ActiveRecord object, Hash or Array of Hashes;
   - Last: Hash of options (same as `JSONAPI::Utils#jsonapi_render`).
+
+#### Paginators
+
+If you are rendering a collection of hashes, you'll need to implement the `#pagination_range` method, which returns a range for your resources. For example:
+
+```ruby
+class CustomPaginator < JSONAPI::Paginator
+  def pagination_range(page_params)
+    offset = page_params['offset']
+    limit  = JSONAPI.configuration.default_page_size
+    offset..offset + limit - 1
+  end
+```
+
+And then it can be either set at the resource class level (e.g. UserResource.paginator :custom_paginator) or via config initializer:
+
+```ruby
+# config/initializers/jsonapi_resources.rb
+JSONAPI.configure do |config|
+  config.default_paginator = :custom_paginator
+end
+```
 
 ### Request
 

--- a/lib/jsonapi/utils/support/pagination.rb
+++ b/lib/jsonapi/utils/support/pagination.rb
@@ -44,12 +44,16 @@ module JSONAPI
         #
         # @api private
         def paginator
-          @paginator ||=
-            if JSONAPI.configuration.default_paginator == :paged
-              PagedPaginator.new(page_params)
-            elsif JSONAPI.configuration.default_paginator == :offset
-              OffsetPaginator.new(page_params)
-            end
+          @paginator ||= paginator_klass.new(page_params)
+        end
+
+        # Returns the paginator class to be used in the response's pagination.
+        #
+        # @return [Paginator]
+        #
+        # @api private
+        def paginator_klass
+          "#{JSONAPI.configuration.default_paginator}_paginator".classify.constantize
         end
 
         # Check whether pagination should be applied to the response.
@@ -105,6 +109,8 @@ module JSONAPI
             offset = page_params['offset'].to_i.nonzero? || 0
             limit  = page_params['limit'].to_i.nonzero?  || JSONAPI.configuration.default_page_size
             offset..offset + limit - 1
+          else
+            paginator.pagination_range(page_params)
           end
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,6 +82,7 @@ require 'support/models'
 require 'support/factories'
 require 'support/resources'
 require 'support/controllers'
+require 'support/paginators'
 
 ##
 # Routes

--- a/spec/support/paginators.rb
+++ b/spec/support/paginators.rb
@@ -1,0 +1,7 @@
+class CustomOffsetPaginator < OffsetPaginator
+  def pagination_range(page_params)
+    offset = page_params['offset'].to_i.nonzero? || 0
+    limit  = page_params['limit'].to_i.nonzero?  || JSONAPI.configuration.default_page_size
+    offset..offset + limit - 1
+  end
+end

--- a/spec/support/shared/jsonapi_errors.rb
+++ b/spec/support/shared/jsonapi_errors.rb
@@ -44,6 +44,8 @@ shared_examples_for 'JSON API invalid request' do
 
     context 'with "page"' do
       context 'when using "paged" paginator' do
+        before(:all) { UserResource.paginator :paged }
+
         context 'with invalid number' do
           it 'renders a 400 response' do
             get :index, page: { number: 'foo' }
@@ -81,6 +83,44 @@ shared_examples_for 'JSON API invalid request' do
 
       context 'when using "offset" paginator' do
         before(:all) { UserResource.paginator :offset }
+
+        context 'with invalid offset' do
+          it 'renders a 400 response' do
+            get :index, page: { offset: -1 }
+            expect(response).to have_http_status :bad_request
+            expect(error['title']).to eq('Invalid page value')
+            expect(error['code']).to eq('118')
+          end
+        end
+
+        context 'with invalid limit' do
+          it 'renders a 400 response' do
+            get :index, page: { limit: 'foo' }
+            expect(response).to have_http_status :bad_request
+            expect(error['title']).to eq('Invalid page value')
+            expect(error['code']).to eq('118')
+          end
+        end
+
+        context 'with invalid page param' do
+          it 'renders a 400 response' do
+            get :index, page: { size: 1 }
+            expect(response).to have_http_status :ok
+          end
+        end
+
+        context 'with a "limit" greater than the max limit' do
+          it 'returns the amount of results based on "JSONAPI.configuration.maximum_page_size"' do
+            get :index, page: { limit: 999 }
+            expect(response).to have_http_status :bad_request
+            expect(error['title']).to eq('Invalid page value')
+            expect(error['code']).to eq('118')
+          end
+        end
+      end
+
+      context 'when using "custom" paginator' do
+        before(:all) { UserResource.paginator :custom_offset }
 
         context 'with invalid offset' do
           it 'renders a 400 response' do


### PR DESCRIPTION
This is a proposed fix for: #30 
 
* Global paginators can be configured with
  `JSONAPI.configuration.default_paginator = :your_custom_paginator`
* Custom Paginator ranges for hashes are delegated to
  Paginator#paginaton_range

Notes:

* I noticed that resource specific paginators don't have any tests except for the shared examples. I can add them if desired.
* If this fix is on the right track, I can update the README with some documentation on how to have to implement the `pagination_range` method for custom paginators.