### PR TITLE
Permit page parameters to remove Rails 5 deprecation warning

### DIFF
--- a/lib/jsonapi/utils/support/pagination.rb
+++ b/lib/jsonapi/utils/support/pagination.rb
@@ -72,7 +72,10 @@ module JSONAPI
         #
         # @api private
         def page_params
-          @page_params ||= ActionController::Parameters.new(@request.params[:page] || {})
+          @page_params ||= begin
+            page = @request.params.to_unsafe_hash['page'] || {}
+            ActionController::Parameters.new(page)
+          end
         end
 
         # Define the paginator or range according to the pagination strategy.


### PR DESCRIPTION
* The following error occurs when using this gem with Rails 5

DEPRECATION WARNING: Method with_indifferent_access is deprecated and
will be removed in Rails 5.1, as `ActionController::Parameters` no
longer inherits from hash.

To fix this issue, let's permit all the attributes then pull out the
page parameters. Note that all attributes need to be permitted due
to strong parameters not allowing attributes to be dynamically
permitted.