### PR TITLE
Unformat keys for filter and sort operations.

### DIFF
--- a/lib/jsonapi/utils/support/filter/default.rb
+++ b/lib/jsonapi/utils/support/filter/default.rb
@@ -1,5 +1,17 @@
 module JSONAPI::Utils::Support::Filter
   module Default
+    # Apply default equality filters.
+    #   e.g.: User.where(name: 'Foobar')
+    #
+    # @param records [ActiveRecord::Relation, Array] collection of records
+    #   e.g.: User.all or [{ id: 1, name: 'Tiago' }, { id: 2, name: 'Doug' }]
+    #
+    # @param options [Hash] JU's options
+    #   e.g.: { filter: false, paginate: false }
+    #
+    # @return [ActiveRecord::Relation, Array]
+    #
+    # @api public
     def apply_filter(records, options = {})
       if apply_filter?(records, options)
         records.where(filter_params)
@@ -8,23 +20,45 @@ module JSONAPI::Utils::Support::Filter
       end
     end
 
+    # Check whether default filters should be applied.
+    #
+    # @param records [ActiveRecord::Relation, Array] collection of records
+    #   e.g.: User.all or [{ id: 1, name: 'Tiago' }, { id: 2, name: 'Doug' }]
+    #
+    # @param options [Hash] JU's options
+    #   e.g.: { filter: false, paginate: false }
+    #
+    # @return [Boolean]
+    #
+    # @api public
     def apply_filter?(records, options = {})
       params[:filter].present? && records.respond_to?(:where) &&
         (options[:filter].nil? || options[:filter])
     end
 
+    # Build a Hash with the default filters.
+    #
+    # @return [Hash, NilClass]
+    #
+    # @api public
     def filter_params
       @_filter_params ||=
         case params[:filter]
         when Hash, ActionController::Parameters
-          default_filters.each_with_object({}) do |resource, hash|
-            hash[resource] = params[:filter][resource]
+          default_filters.each_with_object({}) do |field, hash|
+            unformatted_key = @request.unformat_key(field)
+            hash[unformatted_key] = params[:filter][field]
           end
         end
     end
 
     private
 
+    # Take all allowed filters and remove the custom ones.
+    #
+    # @return [Array]
+    #
+    # @api private
     def default_filters
       params[:filter].keys.map(&:to_sym) - @request.resource_klass._custom_filters
     end

--- a/lib/jsonapi/utils/support/filter/default.rb
+++ b/lib/jsonapi/utils/support/filter/default.rb
@@ -46,8 +46,8 @@ module JSONAPI::Utils::Support::Filter
         case params[:filter]
         when Hash, ActionController::Parameters
           default_filters.each_with_object({}) do |field, hash|
-            unformatted_key = @request.unformat_key(field)
-            hash[unformatted_key] = params[:filter][field]
+            unformatted_field = @request.unformat_key(field)
+            hash[unformatted_field] = params[:filter][field]
           end
         end
     end

--- a/lib/jsonapi/utils/support/sort.rb
+++ b/lib/jsonapi/utils/support/sort.rb
@@ -1,36 +1,53 @@
-module JSONAPI
-  module Utils
-    module Support
-      module Sort
-        def apply_sort(records)
-          return records unless params[:sort].present?
+module JSONAPI::Utils::Support
+  module Sort
+    # Apply sort on result set (ascending by default).
+    #   e.g.: User.order(:first_name)
+    #
+    # @param records [ActiveRecord::Relation, Array] collection of records
+    #   e.g.: User.all or [{ id: 1, name: 'Tiago' }, { id: 2, name: 'Doug' }]
+    #
+    # @return [ActiveRecord::Relation, Array]
+    #
+    # @api public
+    def apply_sort(records)
+      return records unless params[:sort].present?
 
-          if records.is_a?(Array)
-            records.sort { |a, b| comp = 0; eval(sort_criteria) }
-          elsif records.respond_to?(:order)
-            records.order(sort_params)
+      if records.is_a?(Array)
+        records.sort { |a, b| comp = 0; eval(sort_criteria) }
+      elsif records.respond_to?(:order)
+        records.order(sort_params)
+      end
+    end
+
+    # Build the criteria to be evaluated wthen applying sort
+    # on Array of Hashes (ascending by default).
+    #
+    # @return [String]
+    #
+    # @api public
+    def sort_criteria
+      @sort_criteria ||=
+        sort_params.reduce('') do |sum, (key, value)|
+          comparables = ["a[:#{key}]", "b[:#{key}]"]
+          comparables.reverse! if value == :desc
+          sum + "comp = comp == 0 ? #{comparables.join(' <=> ')} : comp; "
+        end
+    end
+
+    # Build a Hash with the sort criteria.
+    #
+    # @return [Hash, NilClass]
+    #
+    # @api public
+    def sort_params
+      @_sort_params ||=
+        if params[:sort].present?
+          params[:sort].split(',').each_with_object({}) do |field, hash|
+            unformatted_field = @request.unformat_key(field)
+            desc, field       = unformatted_field.to_s.match(/^([-_])?(\w+)$/i)[1..2]
+            hash[field]       = desc.present? ? :desc : :asc
           end
         end
-
-        def sort_criteria
-          @sort_criteria ||=
-            sort_params.reduce('') do |sum, (key, value)|
-              comparables = ["a[:#{key}]", "b[:#{key}]"]
-              comparables.reverse! if value == :desc
-              sum + "comp = comp == 0 ? #{comparables.join(' <=> ')} : comp; "
-            end
-        end
-
-        def sort_params
-          @_sort_params ||=
-            if params[:sort].present?
-              params[:sort].split(',').each_with_object({}) do |criteria, hash|
-                order, field = criteria.match(/(\-?)(\w+)/i)[1..2]
-                hash[field]  = order == '-' ? :desc : :asc
-              end
-            end
-        end
-      end
     end
   end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -5,6 +5,10 @@ describe PostsController, type: :controller do
 
   before(:all) { FactoryGirl.create_list(:post, 3) }
 
+  before(:each) do
+    JSONAPI.configuration.json_key_format = :underscored_key
+  end
+
   let(:fields)        { (PostResource.fields - %i(id author)).map(&:to_s) }
   let(:relationships) { %w(author) }
   let(:first_post)    { Post.first }


### PR DESCRIPTION
Fixes #39 

There's a bug related to the use of keys other than `:underscored_key` for filter and sort operations.

This PR fixes the above mentioned issue taking advantage of the method `JSONAPI::RequestParser#unformat_key` which converts keys from any format to the standard `:underscored_key` format.