### PR TITLE
Add source.pointer error object for ActiveRecord

### DIFF
--- a/lib/jsonapi/utils/exceptions.rb
+++ b/lib/jsonapi/utils/exceptions.rb
@@ -4,20 +4,48 @@ module JSONAPI
   module Utils
     module Exceptions
       class ActiveRecord < ::JSONAPI::Exceptions::Error
-        attr_accessor :object
+        attr_accessor :object, :associations, :association_keys, :foreign_keys
 
         def initialize(object)
           @object = object
+
+          # Need to reflect on object's associations for error reporting.
+          @associations     = @object.class.reflect_on_all_associations(:belongs_to)
+          @association_keys = @associations.map(&:name)
+          @foreign_keys     = @associations.map(&:foreign_key).map(&:to_sym)
         end
 
         def errors
           object.errors.keys.map do |key|
+            error_meta = error_meta_for(key)
+
             JSONAPI::Error.new(
               code: JSONAPI::VALIDATION_ERROR,
               status: :unprocessable_entity,
-              id: key,
-              title: object.errors.full_messages_for(key).first
+              id: error_meta[:id],
+              title: object.errors.full_messages_for(key).first,
+              source: { pointer: error_meta[:pointer] }
             )
+          end
+        end
+
+        private
+
+        # Returns JSON pointer for a given error key.
+        # See https://tools.ietf.org/html/rfc6901 for more information about
+        # JSON pointers.
+        def error_meta_for(key)
+          # Pointer depends on whether we're using an association, foreign
+          # key, base, or attribute.
+          if association_keys.include?(key)
+            { id: key, pointer: "/data/relationships/#{key}" }
+          elsif foreign_keys.include?(key)
+            error_key = associations.select { |a| a.foreign_key.to_sym == key }.first.name
+            { id: error_key, pointer: "/data/relationships/#{error_key}" }
+          elsif key == :base
+            { id: key, pointer: '/data' }
+          else
+            { id: key, pointer: "/data/attributes/#{key}" }
           end
         end
       end

--- a/lib/jsonapi/utils/exceptions.rb
+++ b/lib/jsonapi/utils/exceptions.rb
@@ -4,58 +4,87 @@ module JSONAPI
   module Utils
     module Exceptions
       class ActiveRecord < ::JSONAPI::Exceptions::Error
-        attr_accessor :object, :resource, :relationships, :relationship_keys, :foreign_keys
+        attr_reader :object, :resource, :relationships, :relationship_keys, :foreign_keys
 
-        def initialize(object, request, context)
+        def initialize(object, resource_klass, context)
           @object = object
-          request = request
-          resource_klass = request.resource_klass
           @resource = resource_klass.new(object, context)
 
-          # Need to reflect on object's associations for error reporting.
+          # Need to reflect on resource's relationships for error reporting.
           @relationships     = resource_klass._relationships.values
           @relationship_keys = @relationships.map(&:name).map(&:to_sym)
           @foreign_keys      = @relationships.map(&:foreign_key).map(&:to_sym)
         end
 
         def errors
-          object.errors.keys.map do |key|
-            error_meta = {
-              code: JSONAPI::VALIDATION_ERROR,
-              status: :unprocessable_entity,
-              title: object.errors.full_messages_for(key).first
-            }
+          object.errors.messages.flat_map do |key, messages|
+            messages.map do |message|
+              error_meta = error_base
+                .merge(title: title_member(key, message))
+                .merge(id: id_member(key))
+                .merge(source_member(key))
 
-            # Determine if this is a foreign key, which will need to look up its
-            # matching association name.
-            is_foreign_key = foreign_keys.include?(key)
-            id = is_foreign_key ? relationships.select { |r| r.foreign_key == key }.first.name : key
-            id = id.to_sym
+              JSONAPI::Error.new(error_meta)
+            end
+          end
+        end
 
-            key_formatter = JSONAPI.configuration.key_formatter
-            error_meta[:id] = key_formatter.format(id).to_sym
+        private
+
+        def id_member(key)
+          id = resource_key_for(key)
+          key_formatter = JSONAPI.configuration.key_formatter
+          key_formatter.format(id).to_sym
+        end
+
+        # Determine if this is a foreign key, which will need to look up its
+        # matching association name.
+        def resource_key_for(key)
+          if foreign_keys.include?(key)
+            relationships.find { |r| r.foreign_key == key }.name.to_sym
+          else
+            key
+          end
+        end
+
+        def source_member(key)
+          Hash.new.tap do |hash|
+            resource_key = resource_key_for(key)
 
             # Pointer should only be created for whitelisted attributes.
-            if resource.fetchable_fields.include?(id) || key == :base
-              error_meta[:source] = {}
+            return hash unless resource.fetchable_fields.include?(resource_key) || key == :base
 
-              # Pointer depends on whether we're using an association, foreign
-              # key, base, or attribute.
-              error_meta[:source][:pointer] =
-                # Relationship
-                if is_foreign_key || relationship_keys.include?(id)
-                  "/data/relationships/#{error_meta[:id]}"
-                # Base
-                elsif key == :base
-                  '/data'
-                # Attribute
-                else
-                  "/data/attributes/#{error_meta[:id]}"
-                end
-            end
+            id = id_member(key)
 
-            JSONAPI::Error.new(error_meta)
+            hash[:source] = {}
+            hash[:source][:pointer] =
+              # Relationship
+              if relationship_keys.include?(resource_key)
+                "/data/relationships/#{id}"
+              # Base
+              elsif key == :base
+                '/data'
+              # Attribute
+              else
+                "/data/attributes/#{id}"
+              end
           end
+        end
+
+        def title_member(key, message)
+          if key == :base
+            message
+          else
+            resource_key = resource_key_for(key)
+            [resource_key.to_s.tr('.', '_').humanize, message].join(' ')
+          end
+        end
+
+        def error_base
+          {
+            code: JSONAPI::VALIDATION_ERROR,
+            status: :unprocessable_entity
+          }
         end
       end
 

--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -14,7 +14,7 @@ module JSONAPI
         alias_method :jsonapi_serialize, :jsonapi_format
 
         def jsonapi_format_errors(data)
-          data   = JSONAPI::Utils::Exceptions::ActiveRecord.new(data, @request, context) if data.is_a?(ActiveRecord::Base)
+          data   = JSONAPI::Utils::Exceptions::ActiveRecord.new(data, @request.resource_klass, context) if data.is_a?(ActiveRecord::Base)
           errors = data.respond_to?(:errors) ? data.errors : data
           JSONAPI::Utils::Support::Error.sanitize(errors).uniq
         end

--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -14,7 +14,7 @@ module JSONAPI
         alias_method :jsonapi_serialize, :jsonapi_format
 
         def jsonapi_format_errors(data)
-          data   = JSONAPI::Utils::Exceptions::ActiveRecord.new(data) if data.is_a?(ActiveRecord::Base)
+          data   = JSONAPI::Utils::Exceptions::ActiveRecord.new(data, @request, context) if data.is_a?(ActiveRecord::Base)
           errors = data.respond_to?(:errors) ? data.errors : data
           JSONAPI::Utils::Support::Error.sanitize(errors).uniq
         end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -411,7 +411,7 @@ describe UsersController, type: :controller do
     end
 
     context 'when validation fails' do
-      it 'render a 422 response' do
+      it 'renders a 422 response' do
         user_params[:data][:attributes].merge!(first_name: nil, last_name: nil)
 
         expect { post :create, user_params }.to change(User, :count).by(0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,7 +95,7 @@ TestApp.routes.draw do
     jsonapi_resources :posts, only: %i(index show)
   end
 
-  jsonapi_resources :posts, only: %i(create)
+  jsonapi_resources :posts, only: %i(create update)
 
   get :index_with_hash, to: 'posts#index_with_hash'
   get :show_with_hash,  to: 'posts#show_with_hash'

--- a/spec/support/controllers.rb
+++ b/spec/support/controllers.rb
@@ -41,6 +41,7 @@ class PostsController < BaseController
   # POST /posts
   def create
     post = Post.new(post_params)
+    post.hidden = 1
     if post.save
       jsonapi_render json: post, status: :created
     else

--- a/spec/support/controllers.rb
+++ b/spec/support/controllers.rb
@@ -7,7 +7,7 @@ class BaseController < ActionController::Base
 end
 
 class PostsController < BaseController
-  before_action :load_user, except: %i(create index_with_hash show_with_hash)
+  before_action :load_user, except: %i(create index_with_hash show_with_hash update)
 
   # GET /users/:user_id/posts
   def index
@@ -44,16 +44,22 @@ class PostsController < BaseController
     if post.save
       jsonapi_render json: post, status: :created
     else
-      # Example of error rendering for Array of Hashes:
-      errors = [{ id: 'title', title: 'Title can\'t be blank', code: '100' }]
-      jsonapi_render_errors json: errors, status: :unprocessable_entity
+      jsonapi_render_errors json: post, status: :unprocessable_entity
     end
+  end
+
+  # PATCH /posts/:id
+  def update
+    post = Post.find(params[:id])
+    # Example of response rendering with error on base
+    post.errors.add(:base, 'This is an error on the base')
+    jsonapi_render_errors json: post, status: :unprocessable_entity
   end
 
   private
 
   def post_params
-    resource_params.merge(user_id: relationship_params[:author])
+    resource_params.merge(user_id: relationship_params[:author], category_id: relationship_params[:category])
   end
 
   def load_user
@@ -87,8 +93,13 @@ class UsersController < BaseController
     if user.save
       jsonapi_render json: user, status: :created
     else
-      # Example of error rendering for ActiveRecord objects:
-      jsonapi_render_errors json: user, status: :unprocessable_entity
+      # Example of error rendering for Array of Hashes:
+      errors = [
+        { id: 'first_name', title: 'First name can\'t be blank', code: '100' },
+        { id: 'last_name',  title: 'Last name can\'t be blank',  code: '100' }
+      ]
+
+      jsonapi_render_errors json: errors, status: :unprocessable_entity
     end
   end
 

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,8 +1,13 @@
 require 'factory_girl'
 
 FactoryGirl.define do
+  factory :category, class: Category do
+    sequence(:title) { |n| "Title for Category #{n}" }
+  end
+
   factory :post, class: Post do
     association :author, factory: :user
+    category
 
     sequence(:id) { |n| n }
     sequence(:title) { |n| "Title for Post #{n}" }

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -12,6 +12,8 @@ FactoryGirl.define do
     sequence(:id) { |n| n }
     sequence(:title) { |n| "Title for Post #{n}" }
     sequence(:body) { |n| "Body for Post #{n}" }
+    content_type :article
+    hidden 'Hidden'
   end
 
   factory :user, class: User do

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -10,6 +10,8 @@ ActiveRecord::Schema.define do
   create_table :posts, force: true do |t|
     t.string   :title
     t.text     :body
+    t.string   :content_type
+    t.string   :hidden
     t.integer  :user_id
     t.integer  :category_id
     t.timestamps null: false
@@ -39,7 +41,14 @@ end
 class Post < ActiveRecord::Base
   belongs_to :author, class_name: 'User', foreign_key: :user_id
   belongs_to :category
-  validates :title, :body, :author, :category_id, presence: true
+  validates :title, :body, :content_type, :hidden, :author, :category_id, presence: true
+  validate :trip_hidden_error
+
+  private
+
+  def trip_hidden_error
+    errors.add(:hidden, 'error was tripped') if title == 'Fail Hidden'
+  end
 end
 
 class Category < ActiveRecord::Base

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -2,14 +2,21 @@ require 'active_record'
 
 # Tables
 ActiveRecord::Schema.define do
+  create_table :categories, force: true do |t|
+    t.string :title
+    t.timestamps null: false
+  end
+
   create_table :posts, force: true do |t|
     t.string   :title
     t.text     :body
     t.integer  :user_id
+    t.integer  :category_id
     t.timestamps null: false
   end
 
   add_index :posts, :user_id
+  add_index :posts, :category_id
 
   create_table :users, force: true do |t|
     t.string   :first_name
@@ -30,6 +37,12 @@ class User < ActiveRecord::Base
 end
 
 class Post < ActiveRecord::Base
-  belongs_to :author, class_name: 'User', foreign_key: 'user_id'
-  validates :title, :body, :author, presence: true
+  belongs_to :author, class_name: 'User', foreign_key: :user_id
+  belongs_to :category
+  validates :title, :body, :author, :category_id, presence: true
+end
+
+class Category < ActiveRecord::Base
+  has_many :posts
+  validates :title, presence: true
 end

--- a/spec/support/resources.rb
+++ b/spec/support/resources.rb
@@ -1,6 +1,12 @@
+class CategoryResource < JSONAPI::Resource
+  attribute :title
+  has_many :posts
+end
+
 class PostResource < JSONAPI::Resource
   attributes :title, :body
   has_one :author
+  has_one :category
 end
 
 module V2

--- a/spec/support/resources.rb
+++ b/spec/support/resources.rb
@@ -4,7 +4,7 @@ class CategoryResource < JSONAPI::Resource
 end
 
 class PostResource < JSONAPI::Resource
-  attributes :title, :body
+  attributes :title, :content_type, :body
   has_one :author
   has_one :category
 end


### PR DESCRIPTION
Closes #38 

-  Handles attributes vs. base vs. relationships in pointer - `/data/attributes/title` vs. `/data` vs.
   `/data/relationships/category`, respectively
-  Smart enough to convert a foreign-key-based validation to the association name - `category_id`
   becomes `category` after reflecting on `belongs_to` associations
-  Needed to move some test stuff around:
   -  Example of rendering for array of hashes moved from PostsController to UsersController
   -  Added contrived base error to UsersController#update
   -  Added Category model for testing foreign-key error key (`category_id`)

Of course, I am open to criticisms, suggestions for refactoring, etc.