### PR TITLE
Add support for classes that include ActiveModel::Model

### DIFF
--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -14,14 +14,16 @@ module JSONAPI
         alias_method :jsonapi_serialize, :jsonapi_format
 
         def jsonapi_format_errors(data)
-          if data.is_a?(ActiveRecord::Base)|| data.singleton_class.include?(ActiveModel::Model)
-            data = JSONAPI::Utils::Exceptions::ActiveRecord.new(data, @request.resource_klass, context)
-          end
+          data = JSONAPI::Utils::Exceptions::ActiveRecord.new(data, @request.resource_klass, context) if active_record_obj?(data)
           errors = data.respond_to?(:errors) ? data.errors : data
           JSONAPI::Utils::Support::Error.sanitize(errors).uniq
         end
 
         private
+
+        def active_record_obj?(data)
+          data.is_a?(ActiveRecord::Base)|| data.singleton_class.include?(ActiveModel::Model)
+        end
 
         def build_response_document(records, options)
           results = JSONAPI::OperationResults.new

--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -14,7 +14,9 @@ module JSONAPI
         alias_method :jsonapi_serialize, :jsonapi_format
 
         def jsonapi_format_errors(data)
-          data   = JSONAPI::Utils::Exceptions::ActiveRecord.new(data, @request.resource_klass, context) if data.is_a?(ActiveRecord::Base)
+          if data.is_a?(ActiveRecord::Base)|| data.singleton_class.include?(ActiveModel::Model)
+            data = JSONAPI::Utils::Exceptions::ActiveRecord.new(data, @request.resource_klass, context)
+          end
           errors = data.respond_to?(:errors) ? data.errors : data
           JSONAPI::Utils::Support::Error.sanitize(errors).uniq
         end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe ProfileController, type: :controller do
+  include_context 'JSON API headers'
+
+  let(:fields)     { (ProfileResource.fields - %i(id)).map(&:to_s) }
+  let(:resource)   { Profile }
+  let(:attributes) { { location: 'Springfield, USA' } }
+
+  let(:body) do
+    {
+      data: {
+        type: 'profiles',
+        id: '1234',
+        attributes: attributes
+      }
+    }
+  end
+
+  describe '#show' do
+    it 'renders from ActiveModel::Model logic' do
+      get :show
+      expect(response).to have_http_status :ok
+      expect(response).to have_primary_data('profiles')
+      expect(response).to have_data_attributes(fields)
+    end
+  end
+
+  describe '#update' do
+    it 'renders a 422 response' do
+      patch :update, params: body
+      expect(response).to have_http_status :unprocessable_entity
+      expect(errors[0]['id']).to eq('location')
+      expect(errors[0]['title']).to eq("Location can't be blank")
+      expect(errors[0]['code']).to eq('100')
+      expect(errors[0]['source']['pointer']).to eq('/data/attributes/location')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,6 +95,8 @@ TestApp.routes.draw do
     jsonapi_resources :posts, shallow: true
   end
 
+  jsonapi_resource :profile
+
   patch :update_with_error_on_base, to: 'posts#update_with_error_on_base'
 
   get :index_with_hash, to: 'posts#index_with_hash'

--- a/spec/support/controllers.rb
+++ b/spec/support/controllers.rb
@@ -125,3 +125,20 @@ class UsersController < BaseController
     end
   end
 end
+
+class ProfileController < BaseController
+  # GET /profile
+  def show
+    profile = Profile.new
+    profile.id = '1234'
+    profile.location = 'Springfield, USA'
+    jsonapi_render json: profile
+  end
+
+  # PATCH /profile
+  def update
+    profile = Profile.new
+    profile.valid?
+    jsonapi_render_errors json: profile, status: :unprocessable_entity
+  end
+end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -55,3 +55,9 @@ class Category < ActiveRecord::Base
   has_many :posts
   validates :title, presence: true
 end
+
+class Profile
+  include ActiveModel::Model
+  attr_accessor :id, :location
+  validates :location, presence: true
+end

--- a/spec/support/resources.rb
+++ b/spec/support/resources.rb
@@ -26,3 +26,7 @@ class UserResource < JSONAPI::Resource
     "#{@model.first_name} #{@model.last_name}"
   end
 end
+
+class ProfileResource < JSONAPI::Resource
+  attribute :location
+end


### PR DESCRIPTION
I have a model in my application that includes `ActiveModel::Model` instead of extending `ActiveRecord::Base`, so I had to make a slight modification to the error formatter in JU to allow for it.

In case you're not familiar with this pattern... Though this [ActiveModel Form Objects example](https://robots.thoughtbot.com/activemodel-form-objects) isn't for an API, hopefully you can see its value in creating models not backed by a specific database table.

The controller specs I setup are basically there to make sure that the renderers don't choke on one of these special resource, not really to test much else functionality other than that.