### PR TITLE
Update jsonapi-resources to 0.8.0

### DIFF
--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '~> 0.7.0'
+  spec.add_runtime_dependency 'jsonapi-resources', '~> 0.8.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/jsonapi/utils/request.rb
+++ b/lib/jsonapi/utils/request.rb
@@ -1,48 +1,87 @@
-module JSONAPI
-  module Utils
-    module Request
-      def jsonapi_request_handling
-        setup_request
-        check_request
-      end
+module JSONAPI::Utils
+  module Request
+    # Setup and check request before action gets actually evaluated.
+    #
+    # @api public
+    def jsonapi_request_handling
+      setup_request
+      check_request
+    end
 
-      def setup_request
-        @request ||=
-          JSONAPI::Request.new(
-            params.dup,
-            context: context,
-            key_formatter: key_formatter,
-            server_error_callbacks: (self.class.server_error_callbacks || [])
-          )
-      end
+    # Instantiate the request object.
+    #
+    # @return [JSONAPI::RequestParser]
+    #
+    # @api public
+    def setup_request
+      @request ||= JSONAPI::RequestParser.new(
+        params,
+        context: context,
+        key_formatter: key_formatter,
+        server_error_callbacks: (self.class.server_error_callbacks || [])
+      )
+    end
 
-      def check_request
-        @request.errors.blank? || jsonapi_render_errors(json: @request)
-      end
+    # Render an error response if the parsed request got any error.
+    #
+    # @api public
+    def check_request
+      @request.errors.blank? || jsonapi_render_errors(json: @request)
+    end
 
-      def resource_params
-        build_params_for(:resource)
-      end
+    # Override the JSONAPI::ActsAsResourceController#process_request method.
+    #
+    # It might be removed when the following line on JR is fixed:
+    # https://github.com/cerebris/jsonapi-resources/blob/release-0-8/lib/jsonapi/acts_as_resource_controller.rb#L62
+    #
+    # @return [String]
+    #
+    # @api public
+    def process_request
+      process_operations
+      render_results(@operation_results)
+    rescue => e
+      handle_exceptions(e)
+    end
 
-      def relationship_params
-        build_params_for(:relationship)
-      end
+    # Helper to get params for the main resource.
+    #
+    # @return [Hash]
+    #
+    # @api public
+    def resource_params
+      build_params_for(:resource)
+    end
 
-      private
+    # Helper to get params for relationship params.
+    #
+    # @return [Hash]
+    #
+    # @api public
+    def relationship_params
+      build_params_for(:relationship)
+    end
 
-      def build_params_for(param_type)
-        return {} if @request.operations.empty?
+    private
 
-        keys      = %i(attributes to_one to_many)
-        operation = @request.operations.find { |e| e.data.keys & keys == keys }
+    # Extract params from request and build a Hash with params
+    # for either the main resource or relationships.
+    #
+    # @return [Hash]
+    #
+    # @api private
+    def build_params_for(param_type)
+      return {} if @request.operations.empty?
 
-        if operation.nil?
-          {}
-        elsif param_type == :relationship
-          operation.data.values_at(:to_one, :to_many).compact.reduce(&:merge)
-        else
-          operation.data[:attributes]
-        end
+      keys = %i(attributes to_one to_many)
+      operation = @request.operations.find { |e| e.options[:data].keys & keys == keys }
+
+      if operation.nil?
+        {}
+      elsif param_type == :relationship
+        operation.options[:data].values_at(:to_one, :to_many).compact.reduce(&:merge)
+      else
+        operation.options[:data][:attributes]
       end
     end
   end

--- a/lib/jsonapi/utils/version.rb
+++ b/lib/jsonapi/utils/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Utils
-    VERSION = '0.4.8'
+    VERSION = '0.4.9'
   end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -96,7 +96,7 @@ describe PostsController, type: :controller do
             expect(response).to have_meta_record_count(4)
 
             expect(json['links']['first']).to be_present
-            expect(json['links']['previous']).to be_present
+            expect(json['links']['prev']).to be_present
             expect(json['links']['next']).to be_present
             expect(json['links']['last']).to be_present
           end
@@ -111,7 +111,7 @@ describe PostsController, type: :controller do
             expect(response).to have_meta_record_count(4)
 
             expect(json['links']['first']).to be_present
-            expect(json['links']['previous']).to be_present
+            expect(json['links']['prev']).to be_present
             expect(json['links']['next']).not_to be_present
             expect(json['links']['last']).to be_present
           end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -205,7 +205,7 @@ describe UsersController, type: :controller do
             expect(response).to have_meta_record_count(User.count)
 
             expect(json['links']['first']).to be_present
-            expect(json['links']['previous']).to be_present
+            expect(json['links']['prev']).to be_present
             expect(json['links']['next']).to be_present
             expect(json['links']['last']).to be_present
           end
@@ -221,7 +221,7 @@ describe UsersController, type: :controller do
             expect(response).to have_meta_record_count(User.count)
 
             expect(json['links']['first']).to be_present
-            expect(json['links']['previous']).to be_present
+            expect(json['links']['prev']).to be_present
             expect(json['links']['last']).to be_present
           end
         end
@@ -266,7 +266,7 @@ describe UsersController, type: :controller do
             expect(response).to have_meta_record_count(User.count)
 
             expect(json['links']['first']).to be_present
-            expect(json['links']['previous']).to be_present
+            expect(json['links']['prev']).to be_present
             expect(json['links']['next']).to be_present
             expect(json['links']['last']).to be_present
           end
@@ -282,7 +282,7 @@ describe UsersController, type: :controller do
             expect(response).to have_meta_record_count(User.count)
 
             expect(json['links']['first']).to be_present
-            expect(json['links']['previous']).to be_present
+            expect(json['links']['prev']).to be_present
             expect(json['links']['last']).to be_present
           end
         end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -9,8 +9,8 @@ describe UsersController, type: :controller do
     JSONAPI.configuration.json_key_format = :underscored_key
   end
 
-  let(:fields)        { (UserResource.fields - %i(id posts)).map(&:to_s) }
-  let(:relationships) { %w(posts) }
+  let(:fields)        { (UserResource.fields - %i(id profile posts)).map(&:to_s) }
+  let(:relationships) { %w(profile posts) }
   let(:attributes)    { { first_name: 'Yehuda', last_name: 'Katz' } }
 
   let(:user_params) do
@@ -30,7 +30,7 @@ describe UsersController, type: :controller do
 
     context 'with "include"' do
       it 'returns only the required relationships in the "included" member' do
-        get :index, include: :posts
+        get :index, include: 'profile,posts'
         expect(response).to have_http_status :ok
         expect(response).to have_primary_data('users')
         expect(response).to have_data_attributes(fields)
@@ -478,6 +478,18 @@ describe UsersController, type: :controller do
         expect(errors[0]['title']).to eq('My custom error message')
         expect(errors[0]['code']).to eq('125')
         expect(errors[0]['source']).to be_nil
+      end
+    end
+  end
+
+  describe 'use of JSONAPI::Resources\' default actions' do
+    let(:user) { User.first }
+
+    describe '#show_relationship' do
+      it do
+        get :show_relationship, user_id: user.id, relationship: 'profile'
+        expect(response).to have_http_status :ok
+        expect(response).to have_primary_data('profiles')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,6 +93,7 @@ JSONAPI.configuration.route_format = :dasherized_route
 TestApp.routes.draw do
   jsonapi_resources :users do
     jsonapi_resources :posts, only: %i(index show)
+    jsonapi_links :profile
   end
 
   jsonapi_resources :posts, only: %i(create)

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -14,11 +14,20 @@ FactoryGirl.define do
     sequence(:first_name) { |n| "User##{n}" }
     sequence(:last_name) { |n| "Lastname##{n}" }
 
+    after(:create) { |user| create(:profile, user: user) }
+
     trait :with_posts do
       transient { post_count 3 }
       after(:create) do |user, e|
         create_list(:post, e.post_count, author: user)
       end
     end
+  end
+
+  factory :profile, class: Profile do
+    user
+
+    sequence(:id) { |n| n }
+    sequence(:nickname) { |n| "Profile##{n}" }
   end
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -17,16 +17,28 @@ ActiveRecord::Schema.define do
     t.boolean  :admin
     t.timestamps null: false
   end
+
+  create_table :profiles, force: true do |t|
+    t.string :nickname
+    t.references :user, index: true, foreign_key: true
+    t.timestamps null: false
+  end
 end
 
 # Models
 class User < ActiveRecord::Base
+  has_one :profile
   has_many :posts
+
   validates :first_name, :last_name, presence: true
 
   def full_name
     "#{first_name} #{last_name}"
   end
+end
+
+class Profile < ActiveRecord::Base
+  belongs_to :user
 end
 
 class Post < ActiveRecord::Base

--- a/spec/support/resources.rb
+++ b/spec/support/resources.rb
@@ -10,13 +10,18 @@ end
 class UserResource < JSONAPI::Resource
   attributes :first_name, :last_name, :full_name
 
+  has_one :profile, class_name: 'Profile'
   has_many :posts
 
   filters :first_name
-
   custom_filters :full_name
 
   def full_name
     "#{@model.first_name} #{@model.last_name}"
   end
+end
+
+class ProfileResource < JSONAPI::Resource
+  attributes :nickname
+  has_one :user, class_name: 'User', foreign_key: 'user_id'
 end


### PR DESCRIPTION
This PR fixes a buggy behavior from `jsonapi-resources`, for one-to-one relationships, reported in #53.