### PR TITLE
First pass at supporting jsonapi-resource 0.9

### DIFF
--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.8.3'
+  spec.add_runtime_dependency 'jsonapi-resources', '0.9.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/jsonapi/utils/request.rb
+++ b/lib/jsonapi/utils/request.rb
@@ -38,8 +38,12 @@ module JSONAPI::Utils
     #
     # @api public
     def process_request
-      process_operations
-      render_results(@operation_results)
+      operations = @request.operations
+      unless JSONAPI.configuration.resource_cache.nil?
+        operations.each {|op| op.options[:cache_serializer] = resource_serializer }
+      end
+      results = process_operations(operations)
+      render_results(results)
     rescue => e
       handle_exceptions(e)
     end

--- a/spec/support/resources.rb
+++ b/spec/support/resources.rb
@@ -16,7 +16,7 @@ end
 class UserResource < JSONAPI::Resource
   attributes :first_name, :last_name, :full_name
 
-  has_one :profile, class_name: 'Profile'
+  has_one :profile, class_name: 'Profile', foreign_key_on: :related
 
   has_many :posts
 


### PR DESCRIPTION
Gets tests passing by fixing changes to process operations, and the new foreign_key_on option.