### PR TITLE
eliminate ActiveRecord as a dependency for errors

### DIFF
--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -22,7 +22,7 @@ module JSONAPI
         private
 
         def active_record_obj?(data)
-          data.is_a?(ActiveRecord::Base)|| data.singleton_class.include?(ActiveModel::Model)
+          defined?(ActiveRecord::Base) && (data.is_a?(ActiveRecord::Base) || data.singleton_class.include?(ActiveModel::Model))
         end
 
         def build_response_document(records, options)


### PR DESCRIPTION
if ActiveRecord is not loaded in your project, but the method `jsonapi_render_errors` is called, the code tries to see if the object passed in is an active record object or not.  But in doing so, it assumed active record is loaded to make said comparison.

If active record is not loaded, now the `active_record_obj?` method in `JSONAPI::Utils::Response::Formatters` always fails, which is good.