### PR TITLE
Return title AND detail for ActiveRecord errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 test_db
 Gemfile.lock
 
+.ruby-version
+.ruby-gemset

--- a/lib/jsonapi/utils/exceptions.rb
+++ b/lib/jsonapi/utils/exceptions.rb
@@ -20,7 +20,8 @@ module JSONAPI
           object.errors.messages.flat_map do |key, messages|
             messages.map do |message|
               error_meta = error_base
-                .merge(title: title_member(key, message))
+                .merge(title: 'Error')
+                .merge(detail: title_member(key, message))
                 .merge(id: id_member(key))
                 .merge(source_member(key))
 

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -237,7 +237,8 @@ describe PostsController, type: :controller do
         expect { subject }.to change(Post, :count).by(0)
         expect(response).to have_http_status :unprocessable_entity
         expect(errors.dig(0, 'id')).to eq('title')
-        expect(errors.dig(0, 'title')).to eq('Title can\'t be blank')
+        expect(errors.dig(0, 'title')).to eq('Error')
+        expect(errors.dig(0, 'detail')).to eq('Title can\'t be blank')
         expect(errors.dig(0, 'code')).to eq('100')
         expect(errors.dig(0, 'source', 'pointer')).to eq('/data/attributes/title')
       end
@@ -255,7 +256,8 @@ describe PostsController, type: :controller do
         expect(subject).to have_http_status :unprocessable_entity
 
         expect(errors.dig(0, 'id')).to eq('author')
-        expect(errors.dig(0, 'title')).to eq('Author can\'t be blank')
+        expect(errors.dig(0, 'title')).to eq('Error')
+        expect(errors.dig(0, 'detail')).to eq('Author can\'t be blank')
         expect(errors.dig(0, 'code')).to eq('100')
         expect(errors.dig(0, 'source', 'pointer')).to eq('/data/relationships/author')
       end
@@ -273,7 +275,8 @@ describe PostsController, type: :controller do
         expect(subject).to have_http_status :unprocessable_entity
 
         expect(errors.dig(0, 'id')).to eq('category')
-        expect(errors.dig(0, 'title')).to eq('Category can\'t be blank')
+        expect(errors.dig(0, 'title')).to eq('Error')
+        expect(errors.dig(0, 'detail')).to eq('Category can\'t be blank')
         expect(errors.dig(0, 'code')).to eq('100')
         expect(errors.dig(0, 'source', 'pointer')).to eq('/data/relationships/category')
       end
@@ -291,7 +294,8 @@ describe PostsController, type: :controller do
         expect(subject).to have_http_status :unprocessable_entity
 
         expect(errors.dig(0, 'id')).to eq('hidden_field')
-        expect(errors.dig(0, 'title')).to eq('Hidden field error was tripped')
+        expect(errors.dig(0, 'title')).to eq('Error')
+        expect(errors.dig(0, 'detail')).to eq('Hidden field error was tripped')
         expect(errors.dig(0, 'code')).to eq('100')
         expect(errors.dig(0, 'source', 'pointer')).to be_nil
       end
@@ -318,7 +322,8 @@ describe PostsController, type: :controller do
         expect(subject).to have_http_status :unprocessable_entity
 
         expect(errors.dig(0, 'id')).to eq('content-type')
-        expect(errors.dig(0, 'title')).to eq('Content type can\'t be blank')
+        expect(errors.dig(0, 'title')).to eq('Error')
+        expect(errors.dig(0, 'detail')).to eq('Content type can\'t be blank')
         expect(errors.dig(0, 'code')).to eq('100')
         expect(errors.dig(0, 'source', 'pointer')).to eq('/data/attributes/content-type')
       end
@@ -338,7 +343,8 @@ describe PostsController, type: :controller do
         expect { subject }.to change(Post, :count).by(0)
         expect(response).to have_http_status :unprocessable_entity
         expect(errors.dig(0, 'id')).to eq('title')
-        expect(errors.dig(0, 'title')).to eq('Заголовок не может быть пустым')
+        expect(errors.dig(0, 'title')).to eq('Error')
+        expect(errors.dig(0, 'detail')).to eq('Заголовок не может быть пустым')
         expect(errors.dig(0, 'code')).to eq('100')
         expect(errors.dig(0, 'source', 'pointer')).to eq('/data/attributes/title')
       end
@@ -366,7 +372,8 @@ describe PostsController, type: :controller do
         expect(response).to have_http_status :unprocessable_entity
 
         expect(errors.dig(0, 'id')).to eq('base')
-        expect(errors.dig(0, 'title')).to eq('This is an error on the base')
+        expect(errors.dig(0, 'title')).to eq('Error')
+        expect(errors.dig(0, 'detail')).to eq('This is an error on the base')
         expect(errors.dig(0, 'code')).to eq('100')
         expect(errors.dig(0, 'source', 'pointer')).to eq('/data')
       end

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -31,7 +31,8 @@ describe ProfileController, type: :controller do
       patch :update, params: body
       expect(response).to have_http_status :unprocessable_entity
       expect(errors.dig(0, 'id')).to eq('nickname')
-      expect(errors.dig(0, 'title')).to eq("Nickname can't be blank")
+      expect(errors.dig(0, 'title')).to eq('Error')
+      expect(errors.dig(0, 'detail')).to eq("Nickname can't be blank")
       expect(errors.dig(0, 'code')).to eq('100')
       expect(errors.dig(0, 'source', 'pointer')).to eq('/data/attributes/nickname')
     end


### PR DESCRIPTION
It seems like we should be populating the detail, if we're choosing only one of the two (title or detail) to populate. But I threw 'Error' in the title field for now so that they're both present. Thoughts? 

All of the examples in the readme for this repo reference detail, https://github.com/tiagopog/jsonapi-utils#request but it wasn't being used in the context of the ActiveRecord error checking.

Without this change, we're having to do custom branching logic to check for the presence of detail first, then fall back to title.