### PR TITLE
Fix for incompatibility with "globalize" gem

### DIFF
--- a/lib/jsonapi/utils/support/sort.rb
+++ b/lib/jsonapi/utils/support/sort.rb
@@ -43,9 +43,9 @@ module JSONAPI::Utils::Support
       @_sort_params ||=
         if params[:sort].present?
           params[:sort].split(',').each_with_object({}) do |field, hash|
-            unformatted_field = @request.unformat_key(field)
-            desc, field       = unformatted_field.to_s.match(/^([-_])?(\w+)$/i)[1..2]
-            hash[field]       = desc.present? ? :desc : :asc
+            unformatted_field  = @request.unformat_key(field)
+            desc, field        = unformatted_field.to_s.match(/^([-_])?(\w+)$/i)[1..2]
+            hash[field.to_sym] = desc.present? ? :desc : :asc
           end
         end
     end


### PR DESCRIPTION
This pull requests fixes an incompatibility with the **globalize** gem [https://github.com/globalize/globalize](url). The gem is used to translate fields of models stored in a database using a translation table for these fields. Most **ActiveRecord** methods are extended to automatically join the translation table and replace the regular field names with the fields from the translation table.
However, the `order` method was not working with the parameters supplied by **jsonapi-utils** because Symbols were expected as keys in the sort parameter hash and not Strings. I added a conversion to the `sort_params` method. This fix should not interfere with the default **ActiveRecord** behavior as it works with both Strings and Symbols.