### PR TITLE
Sort and pagination was applied in wrong order for Arrays

### DIFF
--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -62,8 +62,8 @@ module JSONAPI
 
         def build_collection(records, options = {})
           records = apply_filter(records, options)
-          records = apply_pagination(records, options)
           records = apply_sort(records)
+          records = apply_pagination(records, options)          
           records.respond_to?(:to_ary) ? records.map { |record| turn_into_resource(record, options) } : []
         end
 


### PR DESCRIPTION
Pagination and sorting was not working as expected for Arrays.

Expected behavior: Result is sorted by specified attributes and then paged
Current behavior: The result set was first paged and then the page was sorted by the specified attributes.

This is no issue for ActiveRecord::Collections as .order(), .offset(), and .limit() can be called in any order with the same result.

