### PR TITLE
Calculate page counts on paged paginator

### DIFF
--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -194,6 +194,10 @@ module JSONAPI
             if JSONAPI.configuration.top_level_meta_include_record_count
               data[:record_count] = count_records(records, options)
             end
+
+            if JSONAPI.configuration.top_level_meta_include_page_count
+              data[:page_count] = count_pages(records, options)
+            end
           end
         end
 

--- a/lib/jsonapi/utils/support/pagination.rb
+++ b/lib/jsonapi/utils/support/pagination.rb
@@ -139,6 +139,16 @@ module JSONAPI
             records.except(:group, :order).count("DISTINCT #{records.table.name}.id")
           end
         end
+
+        def count_pages(records, options)
+          record_count = count_records(records, options)
+
+          case JSONAPI.configuration.default_paginator
+          when :paged
+            size = page_params['size'].to_i.nonzero? || JSONAPI.configuration.default_page_size
+            (record_count.to_f / size).ceil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
I found out JU doesn't calculate the `page_count` even the `config.top_level_meta_include_page_count` is set, which creates some trouble when making the pagination UI.
After digging into the code, looks like the `page_count` option has never be set.

Please check if this could fix the missing `page_count` or it is intended not to include `page_count` at the very first. Thank you 👍 