### PR TITLE
Improvement/record count refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ rvm:
   - 2.3.3
 matrix:
 before_install: gem install bundler -v 1.13.6
-script: bundle exec rspec spec/controllers
+script: bundle exec rspec spec
 

--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -171,7 +171,7 @@ module JSONAPI
           end
         end
 
-        # Apply some result options like pagination params and count to a collection response.
+        # Apply some result options like pagination params and record count to collection responses.
         #
         # @param records [ActiveRecord::Relation, Hash, Array<Hash>]
         #   Object to be formatted into JSON
@@ -192,7 +192,7 @@ module JSONAPI
             end
 
             if JSONAPI.configuration.top_level_meta_include_record_count
-              data[:record_count] = count_records(records, options)
+              data[:record_count] = record_count_for(records, options)
             end
           end
         end

--- a/lib/jsonapi/utils/support/pagination.rb
+++ b/lib/jsonapi/utils/support/pagination.rb
@@ -172,10 +172,16 @@ module JSONAPI
         # @api private
         def count_records_from_database(records, options)
           records = apply_filter(records, options) if params[:filter].present?
-          count   = -> (records, except: []) { records.except(*except).distinct.count }
+          count   = -> (records, except: []) do
+            records.except(*except).count(distinct_count_sql(records))
+          end
           count.(records, except: %i(includes group order))
         rescue ActiveRecord::StatementInvalid
           count.(records, except: %i(group order))
+        end
+
+        def distinct_count_sql(records)
+          "DISTINCT #{records.table_name}.#{records.primary_key}"
         end
       end
     end

--- a/lib/jsonapi/utils/support/pagination.rb
+++ b/lib/jsonapi/utils/support/pagination.rb
@@ -38,7 +38,7 @@ module JSONAPI
           paginator.links_page_params(record_count: record_count_for(records, options))
         end
 
-        # Apply memoization to the record count result avoiding then duplicate counts.
+        # Apply memoization to the record count result avoiding duplicate counts.
         #
         # @param records [ActiveRecord::Relation, Array] collection of records
         #   e.g.: User.all or [{ id: 1, name: 'Tiago' }, { id: 2, name: 'Doug' }]
@@ -172,7 +172,7 @@ module JSONAPI
         # @api private
         def count_records_from_database(records, options)
           records = apply_filter(records, options) if params[:filter].present?
-          count   = -> (records, except: []) do
+          count   = -> (records, except:) do
             records.except(*except).count(distinct_count_sql(records))
           end
           count.(records, except: %i(includes group order))
@@ -180,6 +180,15 @@ module JSONAPI
           count.(records, except: %i(group order))
         end
 
+        # Build the SQL distinct count with some reflection on the "records" object.
+        #
+        # @param records [ActiveRecord::Relation] collection of records
+        #   e.g.: User.all
+        #
+        # @return [String]
+        #   e.g.: "DISTINCT users.id"
+        #
+        # @api private
         def distinct_count_sql(records)
           "DISTINCT #{records.table_name}.#{records.primary_key}"
         end

--- a/lib/jsonapi/utils/support/pagination.rb
+++ b/lib/jsonapi/utils/support/pagination.rb
@@ -35,7 +35,23 @@ module JSONAPI
         # @api public
         def pagination_params(records, options)
           return {} unless JSONAPI.configuration.top_level_links_include_pagination
-          paginator.links_page_params(record_count: count_records(records, options))
+          paginator.links_page_params(record_count: record_count_for(records, options))
+        end
+
+        # Apply memoization to the record count result avoiding then duplicate counts.
+        #
+        # @param records [ActiveRecord::Relation, Array] collection of records
+        #   e.g.: User.all or [{ id: 1, name: 'Tiago' }, { id: 2, name: 'Doug' }]
+        #
+        # @param options [Hash] JU's options
+        #   e.g.: { resource: V2::UserResource, count: 100 }
+        #
+        # @return [Integer]
+        #   e.g.: 42
+        #
+        # @api public
+        def record_count_for(records, options)
+          @record_count ||= count_records(records, options)
         end
 
         private

--- a/lib/jsonapi/utils/version.rb
+++ b/lib/jsonapi/utils/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Utils
-    VERSION = '0.7.0'.freeze
+    VERSION = '0.7.1'.freeze
   end
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe PostsController, type: :controller do
   include_context 'JSON API headers'

--- a/spec/controllers/profile_controller_spec.rb
+++ b/spec/controllers/profile_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe ProfileController, type: :controller do
   include_context 'JSON API headers'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe UsersController, type: :controller do
   include_context 'JSON API headers'

--- a/spec/features/record_count_spec.rb
+++ b/spec/features/record_count_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper'
+
+##
+# Configs
+##
+
+# Resource
+class RecordCountTestResource < JSONAPI::Resource; end
+
+# Controller
+class RecordCountTestController < BaseController
+  def explicit_count
+    jsonapi_render json: User.all, options: { count: 42, resource: UserResource }
+  end
+
+  def array_count
+    jsonapi_render json: User.all.to_a, options: { resource: UserResource }
+  end
+
+  def active_record_count
+    jsonapi_render json: User.all, options: { resource: UserResource }
+  end
+
+  def active_record_count_with_eager_load
+    users = User.all.includes(:posts)
+    jsonapi_render json: users, options: { resource: UserResource }
+  end
+
+  def active_record_count_with_eager_load_and_where_clause
+    users = User.all.includes(:posts).where(posts: { id: Post.first.id })
+    jsonapi_render json: users, options: { resource: UserResource }
+  end
+end
+
+# Routes
+TestApp.routes.draw do
+  controller :record_count_test do
+    get :explicit_count
+    get :array_count
+    get :active_record_count
+    get :active_record_count_with_eager_load
+    get :active_record_count_with_eager_load_and_where_clause
+  end
+end
+
+##
+# Feature tests
+##
+
+describe RecordCountTestController, type: :controller do
+  include_context 'JSON API headers'
+
+  before(:all) do
+    JSONAPI.configuration.json_key_format = :underscored_key
+    FactoryGirl.create_list(:user, 3, :with_posts)
+  end
+
+  describe 'explicit count' do
+    it 'returns the count based on the passed "options"' do
+      get :explicit_count
+      expect(response).to have_meta_record_count(42)
+    end
+  end
+
+  describe 'array count' do
+    it 'returns the count based on the array length' do
+      get :array_count
+      expect(response).to have_meta_record_count(User.count)
+    end
+  end
+
+  describe 'active record count' do
+    it 'returns the count based on the AR\'s query result' do
+      get :active_record_count
+      expect(response).to have_meta_record_count(User.count)
+    end
+  end
+
+  describe 'active record count with eager load' do
+    it 'returns the count based on the AR\'s query result' do
+      get :active_record_count_with_eager_load
+      expect(response).to have_meta_record_count(User.count)
+    end
+  end
+
+  describe 'active record count with eager load and where clause' do
+    it 'returns the count based on the AR\'s query result' do
+      get :active_record_count_with_eager_load_and_where_clause
+      count = User.joins(:posts).where(posts: { id: Post.first.id }).count
+      expect(response).to have_meta_record_count(count)
+    end
+  end
+end

--- a/spec/features/record_count_spec.rb
+++ b/spec/features/record_count_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 ##
 # Configs

--- a/spec/features/record_count_spec.rb
+++ b/spec/features/record_count_spec.rb
@@ -33,13 +33,17 @@ class RecordCountTestController < BaseController
 end
 
 # Routes
-TestApp.routes.draw do
-  controller :record_count_test do
-    get :explicit_count
-    get :array_count
-    get :active_record_count
-    get :active_record_count_with_eager_load
-    get :active_record_count_with_eager_load_and_where_clause
+def TestApp.draw_record_count_test_routes
+  JSONAPI.configuration.json_key_format = :underscored_key
+
+  TestApp.routes.draw do
+    controller :record_count_test do
+      get :explicit_count
+      get :array_count
+      get :active_record_count
+      get :active_record_count_with_eager_load
+      get :active_record_count_with_eager_load_and_where_clause
+    end
   end
 end
 
@@ -51,7 +55,7 @@ describe RecordCountTestController, type: :controller do
   include_context 'JSON API headers'
 
   before(:all) do
-    JSONAPI.configuration.json_key_format = :underscored_key
+    TestApp.draw_record_count_test_routes
     FactoryGirl.create_list(:user, 3, :with_posts)
   end
 

--- a/spec/jsonapi/utils/support/pagination_spec.rb
+++ b/spec/jsonapi/utils/support/pagination_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+describe JSONAPI::Utils::Support::Pagination do
+  subject do
+    OpenStruct.new(params: {}).extend(JSONAPI::Utils::Support::Pagination)
+  end
+
+  before(:all) do
+    FactoryGirl.create_list(:user, 2)
+  end
+
+  let(:options) { {} }
+
+  ##
+  # Public API
+  ##
+
+  describe '#record_count_for' do
+    context 'with array' do
+      let(:records) { User.all.to_a }
+
+      it 'applies memoization on the record count' do
+        expect(records).to receive(:length).and_return(records.length).once
+        2.times { subject.record_count_for(records, options) }
+      end
+    end
+
+    context 'with ActiveRecord object' do
+      let(:records) { User.all }
+
+      it 'applies memoization on the record count' do
+        expect(records).to receive(:except).and_return(records).once
+        2.times { subject.record_count_for(records, options) }
+      end
+    end
+  end
+
+  ##
+  # Private API
+  ##
+
+  describe '#count_records' do
+    shared_examples_for 'counting records' do
+      it 'counts records' do
+        expect(subject.send(:count_records, records, options)).to eq(count)
+      end
+    end
+
+    context 'with count present within the options' do
+      let(:records) { User.all }
+      let(:options) { { count: 999 } }
+      let(:count)   { 999 }
+      it_behaves_like 'counting records'
+    end
+
+    context 'with array' do
+      let(:records) { User.all.to_a }
+      let(:count)   { records.length }
+      it_behaves_like 'counting records'
+    end
+
+    context 'with ActiveRecord object' do
+      let(:records) { User.all }
+      let(:count)   { records.count }
+      it_behaves_like 'counting records'
+    end
+
+    context 'when no strategy can be applied' do
+      let(:records) { Object.new }
+      let(:count)   { }
+
+      it 'raises an error' do
+        expect {
+          subject.send(:count_records, records, options)
+        }.to raise_error(JSONAPI::Utils::Support::Pagination::RecordCountError)
+      end
+    end
+  end
+
+  describe '#count_records_from_database' do
+    shared_examples_for 'skipping eager load SQL when counting records' do
+      it 'skips any eager load for the SQL count query (default)' do
+        expect(records).to receive(:except)
+          .with(:includes, :group, :order)
+          .and_return(User.all)
+          .once
+        expect(records).to receive(:except)
+          .with(:group, :order)
+          .and_return(User.all)
+          .exactly(0)
+          .times
+        subject.send(:count_records_from_database, records, options)
+      end
+    end
+
+    context 'when not eager loading records' do
+      let(:records) { User.all }
+      it_behaves_like 'skipping eager load SQL when counting records'
+    end
+
+    context 'when eager loading records' do
+      let(:records) { User.includes(:posts) }
+      it_behaves_like 'skipping eager load SQL when counting records'
+    end
+
+    context 'when eager loading records and using where clause on associations' do
+      let(:records) { User.includes(:posts).where(posts: { id: 1 }) }
+
+      it 'fallbacks to the SQL count query with eager load' do
+        expect(records).to receive(:except)
+          .with(:includes, :group, :order)
+          .and_raise(ActiveRecord::StatementInvalid)
+          .once
+        expect(records).to receive(:except)
+          .with(:group, :order)
+          .and_return(User.all)
+          .once
+        subject.send(:count_records_from_database, records, options)
+      end
+    end
+  end
+
+  describe '#distinct_count_sql' do
+    let(:records) { OpenStruct.new(table_name: 'foos', primary_key: 'id') }
+
+    it 'builds the distinct count SQL query' do
+      expect(subject.send(:distinct_count_sql, records)).to eq('DISTINCT foos.id')
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,7 +12,8 @@ require 'support/factories'
 require 'support/resources'
 require 'support/controllers'
 require 'support/paginators'
-require 'support/application'
 
 require 'support/shared/jsonapi_errors'
 require 'support/shared/jsonapi_request'
+
+require 'test_app'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+require 'rails/all'
+require 'rails/test_help'
+require 'rspec/rails'
+
+require 'jsonapi-resources'
+require 'jsonapi/utils'
+
+require 'support/models'
+require 'support/factories'
+require 'support/resources'
+require 'support/controllers'
+require 'support/paginators'
+require 'support/application'
+
+require 'support/shared/jsonapi_errors'
+require 'support/shared/jsonapi_request'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,3 +17,14 @@ require 'support/shared/jsonapi_errors'
 require 'support/shared/jsonapi_request'
 
 require 'test_app'
+
+RSpec.configure do |config|
+  config.before(:all) do
+    TestApp.draw_app_routes
+
+    %w[posts categories profiles users].each do |table_name|
+      ActiveRecord::Base.connection.execute("DELETE FROM #{table_name}; VACUUM;")
+    end
+  end
+end
+

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,4 +27,3 @@ RSpec.configure do |config|
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,6 @@
-require 'rails/all'
-require 'rails/test_help'
-require 'rspec/rails'
 require 'smart_rspec'
 require 'factory_girl'
-
-require 'jsonapi-resources'
-require 'jsonapi/utils'
-
 require 'support/helpers'
-
-##
-# General configs
-##
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
@@ -24,85 +13,4 @@ RSpec.configure do |config|
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
   end
-
-  config.before(:all) do
-    %w(posts categories profiles users).each do |table_name|
-      ActiveRecord::Base.connection.execute("DELETE FROM #{table_name}; VACUUM;")
-    end
-  end
-end
-
-Rails.env = 'test'
-
-JSONAPI.configure do |config|
-  config.json_key_format = :underscored_key
-
-  config.allow_include = true
-  config.allow_sort = true
-  config.allow_filter = true
-
-  config.default_page_size = 10
-  config.maximum_page_size = 10
-  config.default_paginator = :paged
-  config.top_level_links_include_pagination = true
-
-  config.top_level_meta_include_record_count = true
-  config.top_level_meta_record_count_key = :record_count
-end
-
-##
-# Rails application
-##
-
-puts "RAILS VERSION: #{Rails.version}"
-
-class TestApp < Rails::Application
-  config.eager_load = false
-  config.root = File.dirname(__FILE__)
-  config.session_store :cookie_store, key: 'session'
-  config.secret_key_base = 'secret'
-
-  # Raise errors on unsupported parameters
-  config.action_controller.action_on_unpermitted_parameters = :log
-
-  ActiveRecord::Schema.verbose = false
-  config.active_record.schema_format = :none
-  config.active_support.test_order = :random
-
-  # Turn off millisecond precision to maintain Rails 4.0 and 4.1 compatibility in test results
-  Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR >= 1 &&
-    ActiveSupport::JSON::Encoding.time_precision = 0
-
-  I18n.enforce_available_locales = false
-  I18n.available_locales = [:en, :ru]
-  I18n.default_locale = :en
-  I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
-end
-
-Dir[Rails.root.join('support/shared/**/*.rb')].each { |f| require f }
-
-require 'support/models'
-require 'support/factories'
-require 'support/resources'
-require 'support/controllers'
-require 'support/paginators'
-
-##
-# Routes
-##
-
-JSONAPI.configuration.route_format = :dasherized_route
-
-TestApp.routes.draw do
-  jsonapi_resources :users do
-    jsonapi_links :profile
-    jsonapi_resources :posts, shallow: true
-  end
-
-  jsonapi_resource :profile
-
-  patch :update_with_error_on_base, to: 'posts#update_with_error_on_base'
-
-  get :index_with_hash, to: 'posts#index_with_hash'
-  get :show_with_hash,  to: 'posts#show_with_hash'
 end

--- a/spec/support/application.rb
+++ b/spec/support/application.rb
@@ -1,0 +1,79 @@
+##
+# General configs
+##
+
+RSpec.configure do |config|
+  config.before(:all) do
+    %w[posts categories profiles users].each do |table_name|
+      ActiveRecord::Base.connection.execute("DELETE FROM #{table_name}; VACUUM;")
+    end
+  end
+end
+
+JSONAPI.configure do |config|
+  config.json_key_format = :underscored_key
+
+  config.allow_include = true
+  config.allow_sort = true
+  config.allow_filter = true
+
+  config.default_page_size = 10
+  config.maximum_page_size = 10
+  config.default_paginator = :paged
+  config.top_level_links_include_pagination = true
+
+  config.top_level_meta_include_record_count = true
+  config.top_level_meta_record_count_key = :record_count
+end
+
+##
+# Rails application
+##
+
+Rails.env = 'test'
+puts "Rails version: #{Rails.version}"
+
+class TestApp < Rails::Application
+  config.eager_load = false
+  config.root = File.dirname(__FILE__)
+  config.session_store :cookie_store, key: 'session'
+  config.secret_key_base = 'secret'
+
+  # Raise errors on unsupported parameters
+  config.action_controller.action_on_unpermitted_parameters = :log
+
+  ActiveRecord::Schema.verbose = false
+  config.active_record.schema_format = :none
+  config.active_support.test_order = :random
+
+  # Turn off millisecond precision to maintain Rails 4.0 and 4.1 compatibility in test results
+  Rails::VERSION::MAJOR >= 4 && Rails::VERSION::MINOR >= 1 &&
+    ActiveSupport::JSON::Encoding.time_precision = 0
+
+  I18n.enforce_available_locales = false
+  I18n.available_locales = [:en, :ru]
+  I18n.default_locale = :en
+  I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
+end
+
+Dir[Rails.root.join('support/shared/**/*.rb')].each { |f| require f }
+
+##
+# Routes
+##
+
+JSONAPI.configuration.route_format = :dasherized_route
+
+TestApp.routes.draw do
+  jsonapi_resources :users do
+    jsonapi_links :profile
+    jsonapi_resources :posts, shallow: true
+  end
+
+  jsonapi_resource :profile
+
+  patch :update_with_error_on_base, to: 'posts#update_with_error_on_base'
+
+  get :index_with_hash, to: 'posts#index_with_hash'
+  get :show_with_hash,  to: 'posts#show_with_hash'
+end

--- a/spec/test_app.rb
+++ b/spec/test_app.rb
@@ -2,14 +2,6 @@
 # General configs
 ##
 
-RSpec.configure do |config|
-  config.before(:all) do
-    %w[posts categories profiles users].each do |table_name|
-      ActiveRecord::Base.connection.execute("DELETE FROM #{table_name}; VACUUM;")
-    end
-  end
-end
-
 JSONAPI.configure do |config|
   config.json_key_format = :underscored_key
 
@@ -31,7 +23,6 @@ end
 ##
 
 Rails.env = 'test'
-puts "Rails version: #{Rails.version}"
 
 class TestApp < Rails::Application
   config.eager_load = false
@@ -60,18 +51,22 @@ end
 # Routes
 ##
 
-JSONAPI.configuration.route_format = :dasherized_route
+def TestApp.draw_app_routes
+  JSONAPI.configuration.route_format = :dasherized_route
 
-TestApp.routes.draw do
-  jsonapi_resources :users do
-    jsonapi_links :profile
-    jsonapi_resources :posts, shallow: true
+  TestApp.routes.draw do
+    jsonapi_resources :users do
+      jsonapi_links :profile
+      jsonapi_resources :posts, shallow: true
+    end
+
+    jsonapi_resource :profile
+
+    patch :update_with_error_on_base, to: 'posts#update_with_error_on_base'
+
+    get :index_with_hash, to: 'posts#index_with_hash'
+    get :show_with_hash,  to: 'posts#show_with_hash'
   end
-
-  jsonapi_resource :profile
-
-  patch :update_with_error_on_base, to: 'posts#update_with_error_on_base'
-
-  get :index_with_hash, to: 'posts#index_with_hash'
-  get :show_with_hash,  to: 'posts#show_with_hash'
 end
+
+puts "\nRunning Rails #{Rails.version} on #{Rails.env} environment"

--- a/spec/test_app.rb
+++ b/spec/test_app.rb
@@ -56,8 +56,6 @@ class TestApp < Rails::Application
   I18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}')]
 end
 
-Dir[Rails.root.join('support/shared/**/*.rb')].each { |f| require f }
-
 ##
 # Routes
 ##


### PR DESCRIPTION
Closes #78 

## What's this PR do?

It brings some refactoring + fixes to the record count feature.

## TODOs

- [x] Fix the execution of slow count queries when using AR objects with eager load (i.e. count with left joins);
  - [x] If for some reason the effectiveness of the query is affected for skipping the left joins (e.g. where clauses) then rollback to the slow count;
- [x] Raise an error if no count strategy can be applied;
- [x] Apply memoization on the record count;
- [x] Write specs;
- [x] Bump up the gem's version.

## Background context

At [Beauty Date](https://beautydate.com) we have a production HTTP API fully based on [JSON API](https://jsonapi.org) using `jsonapi-utils` to parse request e build responses. While optimizing an endpoint that was suffering from "N+1 queries" problem, one of our developers (@giovannibonetti) noted that when using eager load on large tables it actually ends up with an extremely low count query because of the left join associations. 

## Manual test

```ruby
# Explicit count
jsonapi_render json: User.all, options: { count: 42 }

# Array count
jsonapi_render json: User.all.to_a

# ActiveRecord count
jsonapi_render json: User.all

# ActiveRecord count with eager load
jsonapi_render json: User.all.includes(:posts)

# ActiveRecord count with eager load and where clause
jsonapi_render json: User.all.includes(:posts).where(posts: { id: Post.first.id }) 
```