### PR TITLE
Allow 0.9.x

### DIFF
--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.9.0'
+  spec.add_runtime_dependency 'jsonapi-resources', '~> 0.9.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
## Why

In order to use some of the back-ports provided in 0.9.1 with this library, we need to loosen the gem dependency to patch-level releases.

## Changes

* Allow `~> 0.9.x` including `0.9.1.beta2`