### PR TITLE
Non-ActiveRecord paginator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@ Content-Type: application/vnd.api+json
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rspec  --pattern "**{,/*/**}/*_spec.rb"` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rspec spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@ Content-Type: application/vnd.api+json
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rspec  --pattern "**{,/*/**}/*_spec.rb"` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'smart_rspec', '~> 0.1.6'
   spec.add_development_dependency 'pry', '~> 0.10.3'
   spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'simplecov'
 end

--- a/lib/jsonapi/utils/support/pagination.rb
+++ b/lib/jsonapi/utils/support/pagination.rb
@@ -150,6 +150,7 @@ module JSONAPI
         def count_records(records, options)
           return options[:count].to_i if options[:count].is_a?(Numeric)
 
+          records = apply_filter(records, options) if params[:filter].present?
           RecordCounter.count( records, params, options )
         end
 
@@ -237,7 +238,6 @@ module JSONAPI
             #
             # @api private
             def count
-              @records = apply_filter(records, options) if params[:filter].present?
               count   = -> (records, except:) do
                 records.except(*except).count(distinct_count_sql(records))
               end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'smart_rspec'
 require 'factory_girl'
 require 'support/helpers'
+require 'simplecov'
+SimpleCov.start
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods

--- a/spec/support/paginators.rb
+++ b/spec/support/paginators.rb
@@ -5,3 +5,16 @@ class CustomOffsetPaginator < OffsetPaginator
     offset..offset + limit - 1
   end
 end
+
+
+class BogusCounter < JSONAPI::Utils::Support::Pagination::RecordCounter::BaseCounter
+  counts "junk"
+end
+
+class StringCounter < JSONAPI::Utils::Support::Pagination::RecordCounter::BaseCounter
+  counts "string"
+
+  def count
+    @records.length
+  end
+end


### PR DESCRIPTION
_First and foremost: thanks so much for putting this gem out here!_

## Problem Statement

I have a service that uses `Elasticsearch` instead of `ActiveRecord` and I would like to return the result set counts. Because `ActiveRecord::Relation` is referenced directly in the counting method, the app explodes. Under the current implementation, my options are to:
* monkeypatch `Pagination.count_records` in every Elasticsearch-backed service I write
* do the counting in the controller and pass it into `jsonapi_render` via `options[:count]`

Option one is really a strawman, and it felt odd to sprinkle `options: { count: MyEsModel.count( params ) }` in every single controller action across multiple controllers in several projects.

## Proposed Contribution

I extracted the underlying counting interface in to a `RecordCounter` module that responds to `count( records, params = {}, options ={} )` and loops through dedicated `Counter` classes that know how to count a specific class type. So like, `ActiveRecord::Relation` objects go to the `ActiveRecordCounter` and `Array`s go to the `ArrayCounter` class. 

The `#{Type}Counter` classes register themselves with `RecordCounter` on declaration with `counts #{Type.to_s.underscore}` making adding new counters as easy as just declaring them in your project.

## What this does

I will admit that this is a somewhat involved change, but there are several benefits to this added complexity. It:

* eliminates the hard dependency on `ActiveRecord::Relation` in the counting mechanism
* allows for easy extensions to counting, both in adding counting for other backend technologies, as well as modifying existing counting functionality without having to modify `JSONAPI::Utils`

## Example

To use my use case, an Elasticsearch-backed system would implement a counter approximately like so:

```ruby
class ElasticsearchCounter < JSONAPI::Utils::Support::Pagination::RecordCounter::BaseCounter
  counts '"elasticsearch/persistence/repository/response/results"

  # the one thing we have to define
  def count
    # not the actual implementation 
    @records.count
  end
end
```
