### PR TITLE
Improvement/metadata on jsonapi render

### DIFF
--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -186,6 +186,8 @@ module JSONAPI
         # @api private
         def result_options(records, options)
           {}.tap do |data|
+	    data[:meta] = options.fetch(:meta, {})
+
             if JSONAPI.configuration.default_paginator != :none &&
               JSONAPI.configuration.top_level_links_include_pagination
               data[:pagination_params] = pagination_params(records, options)

--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -186,7 +186,7 @@ module JSONAPI
         # @api private
         def result_options(records, options)
           {}.tap do |data|
-	    data[:meta] = options.fetch(:meta, {})
+	          data[:meta] = options.fetch(:meta, {})
 
             if JSONAPI.configuration.default_paginator != :none &&
               JSONAPI.configuration.top_level_links_include_pagination


### PR DESCRIPTION
Currently there is no way to pass top-level `meta` objects in the current implementation as it only filters for pagination options, record_count and page_count.

This line allows to `jsonapi_render` to include top-level meta information in the following way:

```ruby
jsonapi_render json: MyResource.first, status: :ok, options: { meta: { author: "Erik Regla", pls_approve_dis: "true" } } 
```