### PR TITLE
Support defining paginator on resource

### DIFF
--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -263,7 +263,7 @@ module JSONAPI
         # @api private
         def result_options(records, options)
           {}.tap do |data|
-            if JSONAPI.configuration.default_paginator != :none &&
+            if apply_pagination?(options) &&
               JSONAPI.configuration.top_level_links_include_pagination
               data[:pagination_params] = pagination_params(records, options)
             end
@@ -273,7 +273,7 @@ module JSONAPI
             end
 
             if JSONAPI.configuration.top_level_meta_include_page_count
-              data[:page_count] = page_count_for(data[:record_count])
+              data[:page_count] = apply_pagination?(options) ? page_count_for(data[:record_count]) : 1
             end
           end
         end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -79,9 +79,9 @@ describe PostsController, type: :controller do
         end
       end
 
-      context 'when using custom global paginator' do
+      context 'when using custom paginator' do
         before(:all) do
-          JSONAPI.configuration.default_paginator = :custom_offset
+          PostResource.paginator :custom_offset
         end
 
         let(:params) { { user_id: parent_id, page: { offset: offset, limit: limit } } }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -101,7 +101,7 @@ describe UsersController, type: :controller do
     context 'with "page"' do
       context 'when using "paged" paginator' do
         before(:all) do
-          JSONAPI.configuration.default_paginator = :paged
+          UserResource.paginator :paged
         end
 
         context 'at the first page' do
@@ -183,7 +183,7 @@ describe UsersController, type: :controller do
 
       context 'when using "offset" paginator' do
         before(:all) do
-          JSONAPI.configuration.default_paginator = :offset
+          UserResource.paginator :offset
         end
 
         context 'at the first page' do
@@ -246,9 +246,9 @@ describe UsersController, type: :controller do
         end
       end
 
-      context 'when using custom global paginator' do
+      context 'when using custom paginator' do
         before(:all) do
-          JSONAPI.configuration.default_paginator = :custom_offset
+          UserResource.paginator :custom_offset
         end
 
         context 'at the first page' do
@@ -308,6 +308,24 @@ describe UsersController, type: :controller do
             expect(response).to have_meta_record_count(User.count)
             expect(json.dig('meta', 'page_count')).to eq(1)
           end
+        end
+      end
+
+      context 'without pagination' do
+        before(:all) do
+          UserResource.paginator :none
+        end
+
+        it 'returns all results without pagination links' do
+          get :index, params: { page: { offset: 0, limit: 2 } }
+
+          expect(response).to have_http_status :ok
+          expect(response).to have_primary_data('users')
+          expect(data.size).to eq(User.count)
+          expect(response).to have_meta_record_count(User.count)
+
+          expect(json.dig('meta', 'page_count')).to eq(1)
+          expect(json.dig('links')).not_to be_present
         end
       end
     end

--- a/spec/jsonapi/utils/support/pagination_spec.rb
+++ b/spec/jsonapi/utils/support/pagination_spec.rb
@@ -77,7 +77,7 @@ describe JSONAPI::Utils::Support::Pagination do
     end
   end
 
-  describe '#count_pages_for' do
+  describe '#page_count_for' do
     shared_examples_for 'counting pages' do
       it 'returns the correct page count' do
         allow(subject).to receive(:page_params).and_return(page_params)

--- a/spec/jsonapi/utils/support/pagination_spec.rb
+++ b/spec/jsonapi/utils/support/pagination_spec.rb
@@ -164,4 +164,39 @@ describe JSONAPI::Utils::Support::Pagination do
       expect(subject.send(:distinct_count_sql, records)).to eq('DISTINCT foos.id')
     end
   end
+
+  describe '#apply_pagination?' do
+    shared_examples_for 'checking pagination' do
+      it 'returns whether to apply pagination' do
+        allow(subject).to receive(:resource_paginator_name).and_return(paginator)
+        expect(subject.send(:apply_pagination?, options)).to eq(apply)
+      end
+    end
+
+    context 'with paged paginator' do
+      let(:paginator) { :paged }
+      let(:apply) { true }
+      it_behaves_like 'checking pagination'
+    end
+
+    context 'without paginator' do
+      let(:paginator) { :none }
+      let(:apply) { false }
+      it_behaves_like 'checking pagination'
+    end
+
+    context 'when options[:paginate] is false' do
+      let(:paginator) { :paged }
+      let(:options) { { paginate: false } }
+      let(:apply) { false }
+      it_behaves_like 'checking pagination'
+    end
+
+    context 'when options[:paginate] is nil' do
+      let(:paginator) { :paged }
+      let(:options) { { paginate: nil } }
+      let(:apply) { true }
+      it_behaves_like 'checking pagination'
+    end
+  end
 end

--- a/spec/support/controllers.rb
+++ b/spec/support/controllers.rb
@@ -14,7 +14,7 @@ class PostsController < BaseController
     jsonapi_render json: @user.posts, options: { count: 100 }
   end
 
-  # GET /users/:user_id//index_with_hash
+  # GET /users/:user_id/index_with_hash
   def index_with_hash
     @posts = { data: [
       { id: 1, title: 'Lorem Ipsum', body: 'Body 4' },


### PR DESCRIPTION
Updates Pagination/Formatters to check the resource paginator instead of the default paginator. Currently, if you've set a paginator directly on your resource, it's ignored in favor of the default. 
