### PR TITLE
updates jsonapi-resources to version 0.9.5

### DIFF
--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,14 +19,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.9.0'
+  spec.add_runtime_dependency 'jsonapi-resources', '0.9.5'
 
-  spec.add_development_dependency 'bundler', '~> 1.10'
+  spec.add_development_dependency 'bundler', '~> 2.0.1'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rails', ENV['RAILS_VERSION'] || '~> 5.1'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
-  spec.add_development_dependency 'factory_girl', '~> 4.8'
+  spec.add_development_dependency 'factory_bot', '~> 4.11', '>= 4.11.1'
   spec.add_development_dependency 'smart_rspec', '~> 0.1.6'
   spec.add_development_dependency 'pry', '~> 0.10.3'
   spec.add_development_dependency 'pry-byebug'

--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rails', ENV['RAILS_VERSION'] || '~> 5.1'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
-  spec.add_development_dependency 'factory_bot', '~> 4.11', '>= 4.11.1'
+  spec.add_development_dependency 'factory_bot', '~> 4.11.1', '>= 4.8.2'
   spec.add_development_dependency 'smart_rspec', '~> 0.1.6'
   spec.add_development_dependency 'pry', '~> 0.10.3'
   spec.add_development_dependency 'pry-byebug'

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -4,7 +4,7 @@ describe PostsController, type: :controller do
   include_context 'JSON API headers'
 
   before(:all) do
-    @post = FactoryGirl.create_list(:post, 3).first
+    @post = FactoryBot.create_list(:post, 3).first
   end
 
   before(:each) do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -22,489 +22,489 @@ describe UsersController, type: :controller do
 
   include_examples 'JSON API invalid request', resource: :users
 
-  # describe '#index' do
-  #   it 'renders a collection of users' do
-  #     get :index
-  #     expect(response).to have_http_status :ok
-  #     expect(response).to have_primary_data('users')
-  #     expect(response).to have_data_attributes(fields)
-  #     expect(response).to have_relationships(relationships)
-  #   end
-
-  #   context 'with "include"' do
-  #     it 'returns only the required relationships in the "included" member' do
-  #       get :index, params: { include: 'profile,posts' }
-  #       expect(response).to have_http_status :ok
-  #       expect(response).to have_primary_data('users')
-  #       expect(response).to have_data_attributes(fields)
-  #       expect(response).to have_relationships(relationships)
-  #       expect(response).to have_included_relationships
-  #     end
-  #   end
-
-  #   context 'with "fields"' do
-  #     it 'returns only the required fields in the "attributes" member' do
-  #       get :index, params: { fields: { users: :first_name } }
-  #       expect(response).to have_http_status :ok
-  #       expect(response).to have_primary_data('users')
-  #       expect(response).to have_data_attributes(%w(first_name))
-  #     end
-  #   end
-
-  #   context 'with "filter"' do
-  #     let(:first_name) { user.first_name }
-  #     let(:full_name)  { "#{user.first_name} #{user.last_name}" }
-
-  #     it 'returns only results corresponding to the applied filter' do
-  #       get :index, params: { filter: { first_name: first_name } }
-  #       expect(response).to have_http_status :ok
-  #       expect(response).to have_primary_data('users')
-  #       expect(response).to have_meta_record_count(1)
-  #       expect(data.dig(0, 'attributes', 'first_name')).to eq(first_name)
-  #     end
-
-  #     it 'returns only results corresponding to the applied custom filter' do
-  #       get :index, params: { filter: { full_name: full_name } }
-  #       expect(response).to have_http_status :ok
-  #       expect(response).to have_primary_data('users')
-  #       expect(response).to have_meta_record_count(1)
-  #       expect(data.dig(0, 'attributes', 'full_name')).to eq(full_name)
-  #     end
-
-  #     context 'when using "dasherized_key"' do
-  #       before do
-  #         JSONAPI.configuration.json_key_format = :dasherized_key
-  #       end
-
-  #       it 'returns only results corresponding to the applied filter' do
-  #         get :index, params: { filter: { 'first-name' => first_name } }
-  #         expect(response).to have_http_status :ok
-  #         expect(response).to have_primary_data('users')
-  #         expect(data.dig(0, 'attributes', 'first-name')).to eq(first_name)
-  #       end
-  #     end
-
-  #     context 'when using "camelized_key"' do
-  #       before do
-  #         JSONAPI.configuration.json_key_format = :camelized_key
-  #       end
-
-  #       it 'returns only results corresponding to the applied filter' do
-  #         get :index, params: { filter: { 'firstName' => first_name } }
-  #         expect(response).to have_http_status :ok
-  #         expect(response).to have_primary_data('users')
-  #         expect(data.dig(0, 'attributes', 'firstName')).to eq(first_name)
-  #       end
-  #     end
-  #   end
-
-  #   context 'with "page"' do
-  #     context 'when using "paged" paginator' do
-  #       before(:all) do
-  #         JSONAPI.configuration.default_paginator = :paged
-  #       end
-
-  #       context 'at the first page' do
-  #         it 'returns paginated results' do
-  #           get :index, params: { page: { number: 1, size: 2 } }
-
-  #           expect(response).to have_http_status :ok
-  #           expect(response).to have_primary_data('users')
-  #           expect(data.size).to eq(2)
-  #           expect(response).to have_meta_record_count(3)
-
-  #           expect(json.dig('meta', 'page_count')).to eq(2)
-  #           expect(json.dig('links', 'first')).to be_present
-  #           expect(json.dig('links', 'next')).to be_present
-  #           expect(json.dig('links', 'last')).to be_present
-  #         end
-  #       end
-
-  #       context 'at the middle' do
-  #         it 'returns paginated results' do
-  #           get :index, params: { page: { number: 2, size: 1 } }
-
-  #           expect(response).to have_http_status :ok
-  #           expect(response).to have_primary_data('users')
-  #           expect(data.size).to eq(1)
-  #           expect(response).to have_meta_record_count(User.count)
-
-  #           expect(json.dig('meta', 'page_count')).to eq(3)
-  #           expect(json.dig('links', 'first')).to be_present
-  #           expect(json.dig('links', 'prev')).to be_present
-  #           expect(json.dig('links', 'next')).to be_present
-  #           expect(json.dig('links', 'last')).to be_present
-  #         end
-  #       end
-
-  #       context 'at the last page' do
-  #         it 'returns paginated results' do
-  #           get :index, params: { page: { number: 3, size: 1 } }
-
-  #           expect(response).to have_http_status :ok
-  #           expect(response).to have_primary_data('users')
-  #           expect(data.size).to eq(1)
-  #           expect(response).to have_meta_record_count(User.count)
-
-  #           expect(json.dig('meta', 'page_count')).to eq(3)
-  #           expect(json.dig('links', 'first')).to be_present
-  #           expect(json.dig('links', 'prev')).to be_present
-  #           expect(json.dig('links', 'last')).to be_present
-  #         end
-  #       end
-
-
-  #       context 'when filtering with pagination' do
-  #         let(:count) { User.where(user.slice(:first_name, :last_name)).count }
-
-  #         it 'returns paginated results according to the given filter' do
-  #           get :index, params: { filter: { full_name: user.full_name }, page: { number: 1, size: 2 } }
-
-  #           expect(response).to have_http_status :ok
-  #           expect(response).to have_primary_data('users')
-  #           expect(data.size).to eq(1)
-  #           expect(response).to have_meta_record_count(count)
-
-  #           expect(json.dig('meta', 'page_count')).to eq(1)
-  #           expect(data.dig(0, 'attributes', 'full_name')).to eq(user.full_name)
-  #         end
-  #       end
-
-  #       context 'without "size"' do
-  #         it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
-  #           get :index, params: { page: { number: 1 } }
-  #           expect(response).to have_http_status :ok
-  #           expect(data.size).to be <= JSONAPI.configuration.default_page_size
-  #           expect(response).to have_meta_record_count(User.count)
-  #           expect(json.dig('meta', 'page_count')).to eq(1)
-  #         end
-  #       end
-  #     end
-
-  #     context 'when using "offset" paginator' do
-  #       before(:all) do
-  #         JSONAPI.configuration.default_paginator = :offset
-  #       end
-
-  #       context 'at the first page' do
-  #         it 'returns paginated results' do
-  #           get :index, params: { page: { offset: 0, limit: 2 } }
-
-  #           expect(response).to have_http_status :ok
-  #           expect(response).to have_primary_data('users')
-  #           expect(data.size).to eq(2)
-  #           expect(response).to have_meta_record_count(User.count)
-
-  #           expect(json.dig('meta', 'page_count')).to eq(2)
-  #           expect(json.dig('links', 'first')).to be_present
-  #           expect(json.dig('links', 'next')).to be_present
-  #           expect(json.dig('links', 'last')).to be_present
-  #         end
-  #       end
-
-  #       context 'at the middle' do
-  #         it 'returns paginated results' do
-  #           get :index, params: { page: { offset: 1, limit: 1 } }
-
-  #           expect(response).to have_http_status :ok
-  #           expect(response).to have_primary_data('users')
-  #           expect(data.size).to eq(1)
-  #           expect(response).to have_meta_record_count(User.count)
-
-  #           expect(json.dig('meta', 'page_count')).to eq(3)
-  #           expect(json.dig('links', 'first')).to be_present
-  #           expect(json.dig('links', 'prev')).to be_present
-  #           expect(json.dig('links', 'next')).to be_present
-  #           expect(json.dig('links', 'last')).to be_present
-  #         end
-  #       end
-
-  #       context 'at the last page' do
-  #         it 'returns the paginated results' do
-  #           get :index, params: { page: { offset: 2, limit: 1 } }
-
-  #           expect(response).to have_http_status :ok
-  #           expect(response).to have_primary_data('users')
-  #           expect(data.size).to eq(1)
-  #           expect(response).to have_meta_record_count(User.count)
-
-  #           expect(json.dig('meta', 'page_count')).to eq(3)
-  #           expect(json.dig('links', 'first')).to be_present
-  #           expect(json.dig('links', 'prev')).to be_present
-  #           expect(json.dig('links', 'last')).to be_present
-  #         end
-  #       end
-
-  #       context 'without "limit"' do
-  #         it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
-  #           get :index, params: { page: { offset: 1 } }
-  #           expect(response).to have_http_status :ok
-  #           expect(data.size).to be <= JSONAPI.configuration.default_page_size
-  #           expect(response).to have_meta_record_count(User.count)
-  #           expect(json.dig('meta', 'page_count')).to eq(1)
-  #         end
-  #       end
-  #     end
-
-  #     context 'when using custom global paginator' do
-  #       before(:all) do
-  #         JSONAPI.configuration.default_paginator = :custom_offset
-  #       end
-
-  #       context 'at the first page' do
-  #         it 'returns paginated results' do
-  #           get :index, params: { page: { offset: 0, limit: 2 } }
-
-  #           expect(response).to have_http_status :ok
-  #           expect(response).to have_primary_data('users')
-  #           expect(data.size).to eq(2)
-  #           expect(response).to have_meta_record_count(User.count)
-
-  #           expect(json.dig('meta', 'page_count')).to eq(2)
-  #           expect(json.dig('links', 'first')).to be_present
-  #           expect(json.dig('links', 'next')).to be_present
-  #           expect(json.dig('links', 'last')).to be_present
-  #         end
-  #       end
-
-  #       context 'at the middle' do
-  #         it 'returns paginated results' do
-  #           get :index, params: { page: { offset: 1, limit: 1 } }
-
-  #           expect(response).to have_http_status :ok
-  #           expect(response).to have_primary_data('users')
-  #           expect(data.size).to eq(1)
-  #           expect(response).to have_meta_record_count(User.count)
-
-  #           expect(json.dig('meta', 'page_count')).to eq(3)
-  #           expect(json.dig('links', 'first')).to be_present
-  #           expect(json.dig('links', 'prev')).to be_present
-  #           expect(json.dig('links', 'next')).to be_present
-  #           expect(json.dig('links', 'last')).to be_present
-  #         end
-  #       end
-
-  #       context 'at the last page' do
-  #         it 'returns the paginated results' do
-  #           get :index, params: { page: { offset: 2, limit: 1 } }
-
-  #           expect(response).to have_http_status :ok
-  #           expect(response).to have_primary_data('users')
-  #           expect(data.size).to eq(1)
-  #           expect(response).to have_meta_record_count(User.count)
-
-  #           expect(json.dig('meta', 'page_count')).to eq(3)
-  #           expect(json.dig('links', 'first')).to be_present
-  #           expect(json.dig('links', 'prev')).to be_present
-  #           expect(json.dig('links', 'last')).to be_present
-  #         end
-  #       end
-
-  #       context 'without "limit"' do
-  #         it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
-  #           get :index, params: { page: { offset: 1 } }
-  #           expect(response).to have_http_status :ok
-  #           expect(data.size).to be <= JSONAPI.configuration.default_page_size
-  #           expect(response).to have_meta_record_count(User.count)
-  #           expect(json.dig('meta', 'page_count')).to eq(1)
-  #         end
-  #       end
-  #     end
-  #   end
-
-  #   context 'with "sort"' do
-  #     context 'when asc' do
-  #       it 'returns sorted results' do
-  #         get :index, params: { sort: :first_name }
-
-  #         first_name1 = data.dig(0, 'attributes', 'first_name')
-  #         first_name2 = data.dig(1, 'attributes', 'first_name')
-
-  #         expect(response).to have_http_status :ok
-  #         expect(response).to have_primary_data('users')
-  #         expect(first_name1).to be <= first_name2
-  #       end
-  #     end
-
-  #     context 'when desc' do
-  #       it 'returns sorted results' do
-  #         get :index, params: { sort: '-first_name,-last_name' }
-
-  #         first_name_1, last_name_1 = data.dig(0, 'attributes').values_at('first_name', 'last_name')
-  #         first_name_2, last_name_2 = data.dig(1, 'attributes').values_at('first_name', 'last_name')
-  #         sorted = first_name_1 > first_name_2 || (first_name_1 == first_name_2 && last_name_1 >= last_name_2)
-
-  #         expect(response).to have_http_status :ok
-  #         expect(response).to have_primary_data('users')
-  #         expect(sorted).to be_truthy
-  #       end
-  #     end
-
-  #     context 'when using "dasherized_key"' do
-  #       before do
-  #         JSONAPI.configuration.json_key_format = :dasherized_key
-  #       end
-
-  #       it 'returns sorted results' do
-  #         get :index, params: { sort: 'first-name' }
-
-  #         first_name_1 = data.dig(0, 'attributes', 'first-name')
-  #         first_name_2 = data.dig(1, 'attributes', 'first-name')
-
-  #         expect(response).to have_http_status :ok
-  #         expect(response).to have_primary_data('users')
-  #         expect(first_name_1 < first_name_2).to be_truthy
-  #       end
-  #     end
-
-  #     context 'when using "camelized_key"' do
-  #       before do
-  #         JSONAPI.configuration.json_key_format = :camelized_key
-  #       end
-
-  #       it 'returns sorted results' do
-  #         get :index, params: { sort: 'firstName' }
-
-  #         first_name_1 = data.dig(0, 'attributes', 'firstName')
-  #         first_name_2 = data.dig(1, 'attributes', 'firstName')
-
-  #         expect(response).to have_http_status :ok
-  #         expect(response).to have_primary_data('users')
-  #         expect(first_name_1 < first_name_2).to be_truthy
-  #       end
-  #     end
-  #   end
-  # end
-
-  # describe '#show' do
-  #   it 'renders a single user' do
-  #     get :show, params: { id: user.id }
-  #     expect(response).to have_http_status :ok
-  #     expect(response).to have_primary_data('users')
-  #     expect(response).to have_data_attributes(fields)
-  #     expect(data.dig('attributes', 'first_name')).to eq("User##{user.id}")
-  #   end
-
-  #   context 'when resource was not found' do
-  #     it 'renders a 404 response' do
-  #       get :show, params: { id: 999 }
-  #       expect(response).to have_http_status :not_found
-  #       expect(error['title']).to eq('Record not found')
-  #       expect(error['code']).to eq('404')
-  #     end
-  #   end
-  # end
-
-  # describe '#create' do
-  #   it 'creates a new user' do
-  #     expect { post :create, params: user_params }.to change(User, :count).by(1)
-  #     expect(response).to have_http_status :created
-  #     expect(response).to have_primary_data('users')
-  #     expect(response).to have_data_attributes(fields)
-  #     expect(data.dig('attributes', 'first_name')).to eq(user_params.dig(:data, :attributes, :first_name))
-  #   end
-
-  #   shared_examples_for '400 response' do |hash|
-  #     before { user_params.dig(:data, :attributes).merge!(hash) }
-
-  #     it 'renders a 400 response' do
-  #       expect { post :create, params: user_params }.to change(User, :count).by(0)
-  #       expect(response).to have_http_status :bad_request
-  #       expect(error['title']).to eq('Param not allowed')
-  #       expect(error['code']).to eq('105')
-  #     end
-  #   end
-
-  #   context 'with a not permitted param' do
-  #     it_behaves_like '400 response', foo: 'bar'
-  #   end
-
-  #   context 'with a param not present in resource\'s attribute list' do
-  #     it_behaves_like '400 response', admin: true
-  #   end
-
-  #   context 'with validation error and no status code set' do
-  #     before { user_params.dig(:data, :attributes).merge!(first_name: nil, last_name: nil) }
-
-  #     it 'renders a 400 response by default' do
-  #       expect { post :create, params: user_params }.to change(User, :count).by(0)
-  #       expect(response).to have_http_status :bad_request
-
-  #       expect(errors.dig(0, 'id')).to eq('first_name')
-  #       expect(errors.dig(0, 'title')).to eq('can\'t be blank')
-  #       expect(errors.dig(0, 'detail')).to eq('First name can\'t be blank')
-  #       expect(errors.dig(0, 'code')).to eq('100')
-  #       expect(errors.dig(0, 'source')).to be_nil
-
-  #       expect(errors.dig(1, 'id')).to eq('last_name')
-  #       expect(errors.dig(1, 'title')).to eq('can\'t be blank')
-  #       expect(errors.dig(1, 'detail')).to eq('Last name can\'t be blank')
-  #       expect(errors.dig(1, 'code')).to eq('100')
-  #       expect(errors.dig(1, 'source')).to be_nil
-  #     end
-  #   end
-  # end
-
-  # describe '#update' do
-  #   let(:post) { user.posts.first }
-
-  #   let(:update_params) do
-  #     user_params.tap do |params|
-  #       params[:data][:id] = user.id
-  #       params[:data][:attributes][:first_name] = 'Yukihiro'
-  #       params[:data][:relationships] = relationship_params
-  #       params.merge!(id: user.id)
-  #     end
-  #   end
-
-  #   let(:relationship_params) do
-  #     { posts: { data: [{ id: post.id, type: 'posts' }] } }
-  #   end
-
-  #   it 'update an existing user' do
-  #     patch :update, params: update_params
-
-  #     expect(response).to have_http_status :ok
-  #     expect(response).to have_primary_data('users')
-  #     expect(response).to have_data_attributes(fields)
-  #     expect(data['attributes']['first_name']).to eq(user_params[:data][:attributes][:first_name])
-
-  #     expect(user.reload.posts.count).to eq(1)
-  #     expect(user.posts.first).to eq(post)
-  #   end
-
-  #   context 'when resource was not found' do
-  #     before { update_params[:data][:id] = 999 }
-
-  #     it 'renders a 404 response' do
-  #       patch :update, params: update_params.merge(id: 999)
-  #       expect(response).to have_http_status :not_found
-  #       expect(error['title']).to eq('Record not found')
-  #       expect(error['code']).to eq('404')
-  #     end
-  #   end
-
-  #   context 'when validation fails' do
-  #     before { update_params[:data][:attributes].merge!(first_name: nil, last_name: nil) }
-
-  #     it 'render a 422 response' do
-  #       patch :update, params: update_params
-  #       expect(response).to have_http_status :unprocessable_entity
-  #       expect(errors[0]['id']).to eq('my_custom_validation_error')
-  #       expect(errors[0]['title']).to eq('My custom error message')
-  #       expect(errors[0]['code']).to eq('125')
-  #       expect(errors[0]['source']).to be_nil
-  #     end
-  #   end
-  # end
-
-  # describe 'use of JSONAPI::Resources\' default actions' do
-  #   describe '#show_relationship' do
-  #     it 'renders the user\'s profile' do
-  #       get :show_relationship, params: { user_id: user.id, relationship: 'profile' }
-  #       expect(response).to have_http_status :ok
-  #       expect(response).to have_primary_data('profiles')
-  #     end
-  #   end
-  # end
+  describe '#index' do
+    it 'renders a collection of users' do
+      get :index
+      expect(response).to have_http_status :ok
+      expect(response).to have_primary_data('users')
+      expect(response).to have_data_attributes(fields)
+      expect(response).to have_relationships(relationships)
+    end
+
+    context 'with "include"' do
+      it 'returns only the required relationships in the "included" member' do
+        get :index, params: { include: 'profile,posts' }
+        expect(response).to have_http_status :ok
+        expect(response).to have_primary_data('users')
+        expect(response).to have_data_attributes(fields)
+        expect(response).to have_relationships(relationships)
+        expect(response).to have_included_relationships
+      end
+    end
+
+    context 'with "fields"' do
+      it 'returns only the required fields in the "attributes" member' do
+        get :index, params: { fields: { users: :first_name } }
+        expect(response).to have_http_status :ok
+        expect(response).to have_primary_data('users')
+        expect(response).to have_data_attributes(%w(first_name))
+      end
+    end
+
+    context 'with "filter"' do
+      let(:first_name) { user.first_name }
+      let(:full_name)  { "#{user.first_name} #{user.last_name}" }
+
+      it 'returns only results corresponding to the applied filter' do
+        get :index, params: { filter: { first_name: first_name } }
+        expect(response).to have_http_status :ok
+        expect(response).to have_primary_data('users')
+        expect(response).to have_meta_record_count(1)
+        expect(data.dig(0, 'attributes', 'first_name')).to eq(first_name)
+      end
+
+      it 'returns only results corresponding to the applied custom filter' do
+        get :index, params: { filter: { full_name: full_name } }
+        expect(response).to have_http_status :ok
+        expect(response).to have_primary_data('users')
+        expect(response).to have_meta_record_count(1)
+        expect(data.dig(0, 'attributes', 'full_name')).to eq(full_name)
+      end
+
+      context 'when using "dasherized_key"' do
+        before do
+          JSONAPI.configuration.json_key_format = :dasherized_key
+        end
+
+        it 'returns only results corresponding to the applied filter' do
+          get :index, params: { filter: { 'first-name' => first_name } }
+          expect(response).to have_http_status :ok
+          expect(response).to have_primary_data('users')
+          expect(data.dig(0, 'attributes', 'first-name')).to eq(first_name)
+        end
+      end
+
+      context 'when using "camelized_key"' do
+        before do
+          JSONAPI.configuration.json_key_format = :camelized_key
+        end
+
+        it 'returns only results corresponding to the applied filter' do
+          get :index, params: { filter: { 'firstName' => first_name } }
+          expect(response).to have_http_status :ok
+          expect(response).to have_primary_data('users')
+          expect(data.dig(0, 'attributes', 'firstName')).to eq(first_name)
+        end
+      end
+    end
+
+    context 'with "page"' do
+      context 'when using "paged" paginator' do
+        before(:all) do
+          JSONAPI.configuration.default_paginator = :paged
+        end
+
+        context 'at the first page' do
+          it 'returns paginated results' do
+            get :index, params: { page: { number: 1, size: 2 } }
+
+            expect(response).to have_http_status :ok
+            expect(response).to have_primary_data('users')
+            expect(data.size).to eq(2)
+            expect(response).to have_meta_record_count(3)
+
+            expect(json.dig('meta', 'page_count')).to eq(2)
+            expect(json.dig('links', 'first')).to be_present
+            expect(json.dig('links', 'next')).to be_present
+            expect(json.dig('links', 'last')).to be_present
+          end
+        end
+
+        context 'at the middle' do
+          it 'returns paginated results' do
+            get :index, params: { page: { number: 2, size: 1 } }
+
+            expect(response).to have_http_status :ok
+            expect(response).to have_primary_data('users')
+            expect(data.size).to eq(1)
+            expect(response).to have_meta_record_count(User.count)
+
+            expect(json.dig('meta', 'page_count')).to eq(3)
+            expect(json.dig('links', 'first')).to be_present
+            expect(json.dig('links', 'prev')).to be_present
+            expect(json.dig('links', 'next')).to be_present
+            expect(json.dig('links', 'last')).to be_present
+          end
+        end
+
+        context 'at the last page' do
+          it 'returns paginated results' do
+            get :index, params: { page: { number: 3, size: 1 } }
+
+            expect(response).to have_http_status :ok
+            expect(response).to have_primary_data('users')
+            expect(data.size).to eq(1)
+            expect(response).to have_meta_record_count(User.count)
+
+            expect(json.dig('meta', 'page_count')).to eq(3)
+            expect(json.dig('links', 'first')).to be_present
+            expect(json.dig('links', 'prev')).to be_present
+            expect(json.dig('links', 'last')).to be_present
+          end
+        end
+
+
+        context 'when filtering with pagination' do
+          let(:count) { User.where(user.slice(:first_name, :last_name)).count }
+
+          it 'returns paginated results according to the given filter' do
+            get :index, params: { filter: { full_name: user.full_name }, page: { number: 1, size: 2 } }
+
+            expect(response).to have_http_status :ok
+            expect(response).to have_primary_data('users')
+            expect(data.size).to eq(1)
+            expect(response).to have_meta_record_count(count)
+
+            expect(json.dig('meta', 'page_count')).to eq(1)
+            expect(data.dig(0, 'attributes', 'full_name')).to eq(user.full_name)
+          end
+        end
+
+        context 'without "size"' do
+          it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
+            get :index, params: { page: { number: 1 } }
+            expect(response).to have_http_status :ok
+            expect(data.size).to be <= JSONAPI.configuration.default_page_size
+            expect(response).to have_meta_record_count(User.count)
+            expect(json.dig('meta', 'page_count')).to eq(1)
+          end
+        end
+      end
+
+      context 'when using "offset" paginator' do
+        before(:all) do
+          JSONAPI.configuration.default_paginator = :offset
+        end
+
+        context 'at the first page' do
+          it 'returns paginated results' do
+            get :index, params: { page: { offset: 0, limit: 2 } }
+
+            expect(response).to have_http_status :ok
+            expect(response).to have_primary_data('users')
+            expect(data.size).to eq(2)
+            expect(response).to have_meta_record_count(User.count)
+
+            expect(json.dig('meta', 'page_count')).to eq(2)
+            expect(json.dig('links', 'first')).to be_present
+            expect(json.dig('links', 'next')).to be_present
+            expect(json.dig('links', 'last')).to be_present
+          end
+        end
+
+        context 'at the middle' do
+          it 'returns paginated results' do
+            get :index, params: { page: { offset: 1, limit: 1 } }
+
+            expect(response).to have_http_status :ok
+            expect(response).to have_primary_data('users')
+            expect(data.size).to eq(1)
+            expect(response).to have_meta_record_count(User.count)
+
+            expect(json.dig('meta', 'page_count')).to eq(3)
+            expect(json.dig('links', 'first')).to be_present
+            expect(json.dig('links', 'prev')).to be_present
+            expect(json.dig('links', 'next')).to be_present
+            expect(json.dig('links', 'last')).to be_present
+          end
+        end
+
+        context 'at the last page' do
+          it 'returns the paginated results' do
+            get :index, params: { page: { offset: 2, limit: 1 } }
+
+            expect(response).to have_http_status :ok
+            expect(response).to have_primary_data('users')
+            expect(data.size).to eq(1)
+            expect(response).to have_meta_record_count(User.count)
+
+            expect(json.dig('meta', 'page_count')).to eq(3)
+            expect(json.dig('links', 'first')).to be_present
+            expect(json.dig('links', 'prev')).to be_present
+            expect(json.dig('links', 'last')).to be_present
+          end
+        end
+
+        context 'without "limit"' do
+          it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
+            get :index, params: { page: { offset: 1 } }
+            expect(response).to have_http_status :ok
+            expect(data.size).to be <= JSONAPI.configuration.default_page_size
+            expect(response).to have_meta_record_count(User.count)
+            expect(json.dig('meta', 'page_count')).to eq(1)
+          end
+        end
+      end
+
+      context 'when using custom global paginator' do
+        before(:all) do
+          JSONAPI.configuration.default_paginator = :custom_offset
+        end
+
+        context 'at the first page' do
+          it 'returns paginated results' do
+            get :index, params: { page: { offset: 0, limit: 2 } }
+
+            expect(response).to have_http_status :ok
+            expect(response).to have_primary_data('users')
+            expect(data.size).to eq(2)
+            expect(response).to have_meta_record_count(User.count)
+
+            expect(json.dig('meta', 'page_count')).to eq(2)
+            expect(json.dig('links', 'first')).to be_present
+            expect(json.dig('links', 'next')).to be_present
+            expect(json.dig('links', 'last')).to be_present
+          end
+        end
+
+        context 'at the middle' do
+          it 'returns paginated results' do
+            get :index, params: { page: { offset: 1, limit: 1 } }
+
+            expect(response).to have_http_status :ok
+            expect(response).to have_primary_data('users')
+            expect(data.size).to eq(1)
+            expect(response).to have_meta_record_count(User.count)
+
+            expect(json.dig('meta', 'page_count')).to eq(3)
+            expect(json.dig('links', 'first')).to be_present
+            expect(json.dig('links', 'prev')).to be_present
+            expect(json.dig('links', 'next')).to be_present
+            expect(json.dig('links', 'last')).to be_present
+          end
+        end
+
+        context 'at the last page' do
+          it 'returns the paginated results' do
+            get :index, params: { page: { offset: 2, limit: 1 } }
+
+            expect(response).to have_http_status :ok
+            expect(response).to have_primary_data('users')
+            expect(data.size).to eq(1)
+            expect(response).to have_meta_record_count(User.count)
+
+            expect(json.dig('meta', 'page_count')).to eq(3)
+            expect(json.dig('links', 'first')).to be_present
+            expect(json.dig('links', 'prev')).to be_present
+            expect(json.dig('links', 'last')).to be_present
+          end
+        end
+
+        context 'without "limit"' do
+          it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
+            get :index, params: { page: { offset: 1 } }
+            expect(response).to have_http_status :ok
+            expect(data.size).to be <= JSONAPI.configuration.default_page_size
+            expect(response).to have_meta_record_count(User.count)
+            expect(json.dig('meta', 'page_count')).to eq(1)
+          end
+        end
+      end
+    end
+
+    context 'with "sort"' do
+      context 'when asc' do
+        it 'returns sorted results' do
+          get :index, params: { sort: :first_name }
+
+          first_name1 = data.dig(0, 'attributes', 'first_name')
+          first_name2 = data.dig(1, 'attributes', 'first_name')
+
+          expect(response).to have_http_status :ok
+          expect(response).to have_primary_data('users')
+          expect(first_name1).to be <= first_name2
+        end
+      end
+
+      context 'when desc' do
+        it 'returns sorted results' do
+          get :index, params: { sort: '-first_name,-last_name' }
+
+          first_name_1, last_name_1 = data.dig(0, 'attributes').values_at('first_name', 'last_name')
+          first_name_2, last_name_2 = data.dig(1, 'attributes').values_at('first_name', 'last_name')
+          sorted = first_name_1 > first_name_2 || (first_name_1 == first_name_2 && last_name_1 >= last_name_2)
+
+          expect(response).to have_http_status :ok
+          expect(response).to have_primary_data('users')
+          expect(sorted).to be_truthy
+        end
+      end
+
+      context 'when using "dasherized_key"' do
+        before do
+          JSONAPI.configuration.json_key_format = :dasherized_key
+        end
+
+        it 'returns sorted results' do
+          get :index, params: { sort: 'first-name' }
+
+          first_name_1 = data.dig(0, 'attributes', 'first-name')
+          first_name_2 = data.dig(1, 'attributes', 'first-name')
+
+          expect(response).to have_http_status :ok
+          expect(response).to have_primary_data('users')
+          expect(first_name_1 < first_name_2).to be_truthy
+        end
+      end
+
+      context 'when using "camelized_key"' do
+        before do
+          JSONAPI.configuration.json_key_format = :camelized_key
+        end
+
+        it 'returns sorted results' do
+          get :index, params: { sort: 'firstName' }
+
+          first_name_1 = data.dig(0, 'attributes', 'firstName')
+          first_name_2 = data.dig(1, 'attributes', 'firstName')
+
+          expect(response).to have_http_status :ok
+          expect(response).to have_primary_data('users')
+          expect(first_name_1 < first_name_2).to be_truthy
+        end
+      end
+    end
+  end
+
+  describe '#show' do
+    it 'renders a single user' do
+      get :show, params: { id: user.id }
+      expect(response).to have_http_status :ok
+      expect(response).to have_primary_data('users')
+      expect(response).to have_data_attributes(fields)
+      expect(data.dig('attributes', 'first_name')).to eq("User##{user.id}")
+    end
+
+    context 'when resource was not found' do
+      it 'renders a 404 response' do
+        get :show, params: { id: 999 }
+        expect(response).to have_http_status :not_found
+        expect(error['title']).to eq('Record not found')
+        expect(error['code']).to eq('404')
+      end
+    end
+  end
+
+  describe '#create' do
+    it 'creates a new user' do
+      expect { post :create, params: user_params }.to change(User, :count).by(1)
+      expect(response).to have_http_status :created
+      expect(response).to have_primary_data('users')
+      expect(response).to have_data_attributes(fields)
+      expect(data.dig('attributes', 'first_name')).to eq(user_params.dig(:data, :attributes, :first_name))
+    end
+
+    shared_examples_for '400 response' do |hash|
+      before { user_params.dig(:data, :attributes).merge!(hash) }
+
+      it 'renders a 400 response' do
+        expect { post :create, params: user_params }.to change(User, :count).by(0)
+        expect(response).to have_http_status :bad_request
+        expect(error['title']).to eq('Param not allowed')
+        expect(error['code']).to eq('105')
+      end
+    end
+
+    context 'with a not permitted param' do
+      it_behaves_like '400 response', foo: 'bar'
+    end
+
+    context 'with a param not present in resource\'s attribute list' do
+      it_behaves_like '400 response', admin: true
+    end
+
+    context 'with validation error and no status code set' do
+      before { user_params.dig(:data, :attributes).merge!(first_name: nil, last_name: nil) }
+
+      it 'renders a 400 response by default' do
+        expect { post :create, params: user_params }.to change(User, :count).by(0)
+        expect(response).to have_http_status :bad_request
+
+        expect(errors.dig(0, 'id')).to eq('first_name')
+        expect(errors.dig(0, 'title')).to eq('can\'t be blank')
+        expect(errors.dig(0, 'detail')).to eq('First name can\'t be blank')
+        expect(errors.dig(0, 'code')).to eq('100')
+        expect(errors.dig(0, 'source')).to be_nil
+
+        expect(errors.dig(1, 'id')).to eq('last_name')
+        expect(errors.dig(1, 'title')).to eq('can\'t be blank')
+        expect(errors.dig(1, 'detail')).to eq('Last name can\'t be blank')
+        expect(errors.dig(1, 'code')).to eq('100')
+        expect(errors.dig(1, 'source')).to be_nil
+      end
+    end
+  end
+
+  describe '#update' do
+    let(:post) { user.posts.first }
+
+    let(:update_params) do
+      user_params.tap do |params|
+        params[:data][:id] = user.id
+        params[:data][:attributes][:first_name] = 'Yukihiro'
+        params[:data][:relationships] = relationship_params
+        params.merge!(id: user.id)
+      end
+    end
+
+    let(:relationship_params) do
+      { posts: { data: [{ id: post.id, type: 'posts' }] } }
+    end
+
+    it 'update an existing user' do
+      patch :update, params: update_params
+
+      expect(response).to have_http_status :ok
+      expect(response).to have_primary_data('users')
+      expect(response).to have_data_attributes(fields)
+      expect(data['attributes']['first_name']).to eq(user_params[:data][:attributes][:first_name])
+
+      expect(user.reload.posts.count).to eq(1)
+      expect(user.posts.first).to eq(post)
+    end
+
+    context 'when resource was not found' do
+      before { update_params[:data][:id] = 999 }
+
+      it 'renders a 404 response' do
+        patch :update, params: update_params.merge(id: 999)
+        expect(response).to have_http_status :not_found
+        expect(error['title']).to eq('Record not found')
+        expect(error['code']).to eq('404')
+      end
+    end
+
+    context 'when validation fails' do
+      before { update_params[:data][:attributes].merge!(first_name: nil, last_name: nil) }
+
+      it 'render a 422 response' do
+        patch :update, params: update_params
+        expect(response).to have_http_status :unprocessable_entity
+        expect(errors[0]['id']).to eq('my_custom_validation_error')
+        expect(errors[0]['title']).to eq('My custom error message')
+        expect(errors[0]['code']).to eq('125')
+        expect(errors[0]['source']).to be_nil
+      end
+    end
+  end
+
+  describe 'use of JSONAPI::Resources\' default actions' do
+    describe '#show_relationship' do
+      it 'renders the user\'s profile' do
+        get :show_relationship, params: { user_id: user.id, relationship: 'profile' }
+        expect(response).to have_http_status :ok
+        expect(response).to have_primary_data('profiles')
+      end
+    end
+  end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -4,7 +4,7 @@ describe UsersController, type: :controller do
   include_context 'JSON API headers'
 
   before(:all) do
-    @user = FactoryGirl.create_list(:user, 3, :with_posts).first
+    @user = FactoryBot.create_list(:user, 3, :with_posts).first
   end
 
   before(:each) do
@@ -22,489 +22,489 @@ describe UsersController, type: :controller do
 
   include_examples 'JSON API invalid request', resource: :users
 
-  describe '#index' do
-    it 'renders a collection of users' do
-      get :index
-      expect(response).to have_http_status :ok
-      expect(response).to have_primary_data('users')
-      expect(response).to have_data_attributes(fields)
-      expect(response).to have_relationships(relationships)
-    end
-
-    context 'with "include"' do
-      it 'returns only the required relationships in the "included" member' do
-        get :index, params: { include: 'profile,posts' }
-        expect(response).to have_http_status :ok
-        expect(response).to have_primary_data('users')
-        expect(response).to have_data_attributes(fields)
-        expect(response).to have_relationships(relationships)
-        expect(response).to have_included_relationships
-      end
-    end
-
-    context 'with "fields"' do
-      it 'returns only the required fields in the "attributes" member' do
-        get :index, params: { fields: { users: :first_name } }
-        expect(response).to have_http_status :ok
-        expect(response).to have_primary_data('users')
-        expect(response).to have_data_attributes(%w(first_name))
-      end
-    end
-
-    context 'with "filter"' do
-      let(:first_name) { user.first_name }
-      let(:full_name)  { "#{user.first_name} #{user.last_name}" }
-
-      it 'returns only results corresponding to the applied filter' do
-        get :index, params: { filter: { first_name: first_name } }
-        expect(response).to have_http_status :ok
-        expect(response).to have_primary_data('users')
-        expect(response).to have_meta_record_count(1)
-        expect(data.dig(0, 'attributes', 'first_name')).to eq(first_name)
-      end
-
-      it 'returns only results corresponding to the applied custom filter' do
-        get :index, params: { filter: { full_name: full_name } }
-        expect(response).to have_http_status :ok
-        expect(response).to have_primary_data('users')
-        expect(response).to have_meta_record_count(1)
-        expect(data.dig(0, 'attributes', 'full_name')).to eq(full_name)
-      end
-
-      context 'when using "dasherized_key"' do
-        before do
-          JSONAPI.configuration.json_key_format = :dasherized_key
-        end
-
-        it 'returns only results corresponding to the applied filter' do
-          get :index, params: { filter: { 'first-name' => first_name } }
-          expect(response).to have_http_status :ok
-          expect(response).to have_primary_data('users')
-          expect(data.dig(0, 'attributes', 'first-name')).to eq(first_name)
-        end
-      end
-
-      context 'when using "camelized_key"' do
-        before do
-          JSONAPI.configuration.json_key_format = :camelized_key
-        end
-
-        it 'returns only results corresponding to the applied filter' do
-          get :index, params: { filter: { 'firstName' => first_name } }
-          expect(response).to have_http_status :ok
-          expect(response).to have_primary_data('users')
-          expect(data.dig(0, 'attributes', 'firstName')).to eq(first_name)
-        end
-      end
-    end
-
-    context 'with "page"' do
-      context 'when using "paged" paginator' do
-        before(:all) do
-          JSONAPI.configuration.default_paginator = :paged
-        end
-
-        context 'at the first page' do
-          it 'returns paginated results' do
-            get :index, params: { page: { number: 1, size: 2 } }
-
-            expect(response).to have_http_status :ok
-            expect(response).to have_primary_data('users')
-            expect(data.size).to eq(2)
-            expect(response).to have_meta_record_count(3)
-
-            expect(json.dig('meta', 'page_count')).to eq(2)
-            expect(json.dig('links', 'first')).to be_present
-            expect(json.dig('links', 'next')).to be_present
-            expect(json.dig('links', 'last')).to be_present
-          end
-        end
-
-        context 'at the middle' do
-          it 'returns paginated results' do
-            get :index, params: { page: { number: 2, size: 1 } }
-
-            expect(response).to have_http_status :ok
-            expect(response).to have_primary_data('users')
-            expect(data.size).to eq(1)
-            expect(response).to have_meta_record_count(User.count)
-
-            expect(json.dig('meta', 'page_count')).to eq(3)
-            expect(json.dig('links', 'first')).to be_present
-            expect(json.dig('links', 'prev')).to be_present
-            expect(json.dig('links', 'next')).to be_present
-            expect(json.dig('links', 'last')).to be_present
-          end
-        end
-
-        context 'at the last page' do
-          it 'returns paginated results' do
-            get :index, params: { page: { number: 3, size: 1 } }
-
-            expect(response).to have_http_status :ok
-            expect(response).to have_primary_data('users')
-            expect(data.size).to eq(1)
-            expect(response).to have_meta_record_count(User.count)
-
-            expect(json.dig('meta', 'page_count')).to eq(3)
-            expect(json.dig('links', 'first')).to be_present
-            expect(json.dig('links', 'prev')).to be_present
-            expect(json.dig('links', 'last')).to be_present
-          end
-        end
-
-
-        context 'when filtering with pagination' do
-          let(:count) { User.where(user.slice(:first_name, :last_name)).count }
-
-          it 'returns paginated results according to the given filter' do
-            get :index, params: { filter: { full_name: user.full_name }, page: { number: 1, size: 2 } }
-
-            expect(response).to have_http_status :ok
-            expect(response).to have_primary_data('users')
-            expect(data.size).to eq(1)
-            expect(response).to have_meta_record_count(count)
-
-            expect(json.dig('meta', 'page_count')).to eq(1)
-            expect(data.dig(0, 'attributes', 'full_name')).to eq(user.full_name)
-          end
-        end
-
-        context 'without "size"' do
-          it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
-            get :index, params: { page: { number: 1 } }
-            expect(response).to have_http_status :ok
-            expect(data.size).to be <= JSONAPI.configuration.default_page_size
-            expect(response).to have_meta_record_count(User.count)
-            expect(json.dig('meta', 'page_count')).to eq(1)
-          end
-        end
-      end
-
-      context 'when using "offset" paginator' do
-        before(:all) do
-          JSONAPI.configuration.default_paginator = :offset
-        end
-
-        context 'at the first page' do
-          it 'returns paginated results' do
-            get :index, params: { page: { offset: 0, limit: 2 } }
-
-            expect(response).to have_http_status :ok
-            expect(response).to have_primary_data('users')
-            expect(data.size).to eq(2)
-            expect(response).to have_meta_record_count(User.count)
-
-            expect(json.dig('meta', 'page_count')).to eq(2)
-            expect(json.dig('links', 'first')).to be_present
-            expect(json.dig('links', 'next')).to be_present
-            expect(json.dig('links', 'last')).to be_present
-          end
-        end
-
-        context 'at the middle' do
-          it 'returns paginated results' do
-            get :index, params: { page: { offset: 1, limit: 1 } }
-
-            expect(response).to have_http_status :ok
-            expect(response).to have_primary_data('users')
-            expect(data.size).to eq(1)
-            expect(response).to have_meta_record_count(User.count)
-
-            expect(json.dig('meta', 'page_count')).to eq(3)
-            expect(json.dig('links', 'first')).to be_present
-            expect(json.dig('links', 'prev')).to be_present
-            expect(json.dig('links', 'next')).to be_present
-            expect(json.dig('links', 'last')).to be_present
-          end
-        end
-
-        context 'at the last page' do
-          it 'returns the paginated results' do
-            get :index, params: { page: { offset: 2, limit: 1 } }
-
-            expect(response).to have_http_status :ok
-            expect(response).to have_primary_data('users')
-            expect(data.size).to eq(1)
-            expect(response).to have_meta_record_count(User.count)
-
-            expect(json.dig('meta', 'page_count')).to eq(3)
-            expect(json.dig('links', 'first')).to be_present
-            expect(json.dig('links', 'prev')).to be_present
-            expect(json.dig('links', 'last')).to be_present
-          end
-        end
-
-        context 'without "limit"' do
-          it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
-            get :index, params: { page: { offset: 1 } }
-            expect(response).to have_http_status :ok
-            expect(data.size).to be <= JSONAPI.configuration.default_page_size
-            expect(response).to have_meta_record_count(User.count)
-            expect(json.dig('meta', 'page_count')).to eq(1)
-          end
-        end
-      end
-
-      context 'when using custom global paginator' do
-        before(:all) do
-          JSONAPI.configuration.default_paginator = :custom_offset
-        end
-
-        context 'at the first page' do
-          it 'returns paginated results' do
-            get :index, params: { page: { offset: 0, limit: 2 } }
-
-            expect(response).to have_http_status :ok
-            expect(response).to have_primary_data('users')
-            expect(data.size).to eq(2)
-            expect(response).to have_meta_record_count(User.count)
-
-            expect(json.dig('meta', 'page_count')).to eq(2)
-            expect(json.dig('links', 'first')).to be_present
-            expect(json.dig('links', 'next')).to be_present
-            expect(json.dig('links', 'last')).to be_present
-          end
-        end
-
-        context 'at the middle' do
-          it 'returns paginated results' do
-            get :index, params: { page: { offset: 1, limit: 1 } }
-
-            expect(response).to have_http_status :ok
-            expect(response).to have_primary_data('users')
-            expect(data.size).to eq(1)
-            expect(response).to have_meta_record_count(User.count)
-
-            expect(json.dig('meta', 'page_count')).to eq(3)
-            expect(json.dig('links', 'first')).to be_present
-            expect(json.dig('links', 'prev')).to be_present
-            expect(json.dig('links', 'next')).to be_present
-            expect(json.dig('links', 'last')).to be_present
-          end
-        end
-
-        context 'at the last page' do
-          it 'returns the paginated results' do
-            get :index, params: { page: { offset: 2, limit: 1 } }
-
-            expect(response).to have_http_status :ok
-            expect(response).to have_primary_data('users')
-            expect(data.size).to eq(1)
-            expect(response).to have_meta_record_count(User.count)
-
-            expect(json.dig('meta', 'page_count')).to eq(3)
-            expect(json.dig('links', 'first')).to be_present
-            expect(json.dig('links', 'prev')).to be_present
-            expect(json.dig('links', 'last')).to be_present
-          end
-        end
-
-        context 'without "limit"' do
-          it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
-            get :index, params: { page: { offset: 1 } }
-            expect(response).to have_http_status :ok
-            expect(data.size).to be <= JSONAPI.configuration.default_page_size
-            expect(response).to have_meta_record_count(User.count)
-            expect(json.dig('meta', 'page_count')).to eq(1)
-          end
-        end
-      end
-    end
-
-    context 'with "sort"' do
-      context 'when asc' do
-        it 'returns sorted results' do
-          get :index, params: { sort: :first_name }
-
-          first_name1 = data.dig(0, 'attributes', 'first_name')
-          first_name2 = data.dig(1, 'attributes', 'first_name')
-
-          expect(response).to have_http_status :ok
-          expect(response).to have_primary_data('users')
-          expect(first_name1).to be <= first_name2
-        end
-      end
-
-      context 'when desc' do
-        it 'returns sorted results' do
-          get :index, params: { sort: '-first_name,-last_name' }
-
-          first_name_1, last_name_1 = data.dig(0, 'attributes').values_at('first_name', 'last_name')
-          first_name_2, last_name_2 = data.dig(1, 'attributes').values_at('first_name', 'last_name')
-          sorted = first_name_1 > first_name_2 || (first_name_1 == first_name_2 && last_name_1 >= last_name_2)
-
-          expect(response).to have_http_status :ok
-          expect(response).to have_primary_data('users')
-          expect(sorted).to be_truthy
-        end
-      end
-
-      context 'when using "dasherized_key"' do
-        before do
-          JSONAPI.configuration.json_key_format = :dasherized_key
-        end
-
-        it 'returns sorted results' do
-          get :index, params: { sort: 'first-name' }
-
-          first_name_1 = data.dig(0, 'attributes', 'first-name')
-          first_name_2 = data.dig(1, 'attributes', 'first-name')
-
-          expect(response).to have_http_status :ok
-          expect(response).to have_primary_data('users')
-          expect(first_name_1 < first_name_2).to be_truthy
-        end
-      end
-
-      context 'when using "camelized_key"' do
-        before do
-          JSONAPI.configuration.json_key_format = :camelized_key
-        end
-
-        it 'returns sorted results' do
-          get :index, params: { sort: 'firstName' }
-
-          first_name_1 = data.dig(0, 'attributes', 'firstName')
-          first_name_2 = data.dig(1, 'attributes', 'firstName')
-
-          expect(response).to have_http_status :ok
-          expect(response).to have_primary_data('users')
-          expect(first_name_1 < first_name_2).to be_truthy
-        end
-      end
-    end
-  end
-
-  describe '#show' do
-    it 'renders a single user' do
-      get :show, params: { id: user.id }
-      expect(response).to have_http_status :ok
-      expect(response).to have_primary_data('users')
-      expect(response).to have_data_attributes(fields)
-      expect(data.dig('attributes', 'first_name')).to eq("User##{user.id}")
-    end
-
-    context 'when resource was not found' do
-      it 'renders a 404 response' do
-        get :show, params: { id: 999 }
-        expect(response).to have_http_status :not_found
-        expect(error['title']).to eq('Record not found')
-        expect(error['code']).to eq('404')
-      end
-    end
-  end
-
-  describe '#create' do
-    it 'creates a new user' do
-      expect { post :create, params: user_params }.to change(User, :count).by(1)
-      expect(response).to have_http_status :created
-      expect(response).to have_primary_data('users')
-      expect(response).to have_data_attributes(fields)
-      expect(data.dig('attributes', 'first_name')).to eq(user_params.dig(:data, :attributes, :first_name))
-    end
-
-    shared_examples_for '400 response' do |hash|
-      before { user_params.dig(:data, :attributes).merge!(hash) }
-
-      it 'renders a 400 response' do
-        expect { post :create, params: user_params }.to change(User, :count).by(0)
-        expect(response).to have_http_status :bad_request
-        expect(error['title']).to eq('Param not allowed')
-        expect(error['code']).to eq('105')
-      end
-    end
-
-    context 'with a not permitted param' do
-      it_behaves_like '400 response', foo: 'bar'
-    end
-
-    context 'with a param not present in resource\'s attribute list' do
-      it_behaves_like '400 response', admin: true
-    end
-
-    context 'with validation error and no status code set' do
-      before { user_params.dig(:data, :attributes).merge!(first_name: nil, last_name: nil) }
-
-      it 'renders a 400 response by default' do
-        expect { post :create, params: user_params }.to change(User, :count).by(0)
-        expect(response).to have_http_status :bad_request
-
-        expect(errors.dig(0, 'id')).to eq('first_name')
-        expect(errors.dig(0, 'title')).to eq('can\'t be blank')
-        expect(errors.dig(0, 'detail')).to eq('First name can\'t be blank')
-        expect(errors.dig(0, 'code')).to eq('100')
-        expect(errors.dig(0, 'source')).to be_nil
-
-        expect(errors.dig(1, 'id')).to eq('last_name')
-        expect(errors.dig(1, 'title')).to eq('can\'t be blank')
-        expect(errors.dig(1, 'detail')).to eq('Last name can\'t be blank')
-        expect(errors.dig(1, 'code')).to eq('100')
-        expect(errors.dig(1, 'source')).to be_nil
-      end
-    end
-  end
-
-  describe '#update' do
-    let(:post) { user.posts.first }
-
-    let(:update_params) do
-      user_params.tap do |params|
-        params[:data][:id] = user.id
-        params[:data][:attributes][:first_name] = 'Yukihiro'
-        params[:data][:relationships] = relationship_params
-        params.merge!(id: user.id)
-      end
-    end
-
-    let(:relationship_params) do
-      { posts: { data: [{ id: post.id, type: 'posts' }] } }
-    end
-
-    it 'update an existing user' do
-      patch :update, params: update_params
-
-      expect(response).to have_http_status :ok
-      expect(response).to have_primary_data('users')
-      expect(response).to have_data_attributes(fields)
-      expect(data['attributes']['first_name']).to eq(user_params[:data][:attributes][:first_name])
-
-      expect(user.reload.posts.count).to eq(1)
-      expect(user.posts.first).to eq(post)
-    end
-
-    context 'when resource was not found' do
-      before { update_params[:data][:id] = 999 }
-
-      it 'renders a 404 response' do
-        patch :update, params: update_params.merge(id: 999)
-        expect(response).to have_http_status :not_found
-        expect(error['title']).to eq('Record not found')
-        expect(error['code']).to eq('404')
-      end
-    end
-
-    context 'when validation fails' do
-      before { update_params[:data][:attributes].merge!(first_name: nil, last_name: nil) }
-
-      it 'render a 422 response' do
-        patch :update, params: update_params
-        expect(response).to have_http_status :unprocessable_entity
-        expect(errors[0]['id']).to eq('my_custom_validation_error')
-        expect(errors[0]['title']).to eq('My custom error message')
-        expect(errors[0]['code']).to eq('125')
-        expect(errors[0]['source']).to be_nil
-      end
-    end
-  end
-
-  describe 'use of JSONAPI::Resources\' default actions' do
-    describe '#show_relationship' do
-      it 'renders the user\'s profile' do
-        get :show_relationship, params: { user_id: user.id, relationship: 'profile' }
-        expect(response).to have_http_status :ok
-        expect(response).to have_primary_data('profiles')
-      end
-    end
-  end
+  # describe '#index' do
+  #   it 'renders a collection of users' do
+  #     get :index
+  #     expect(response).to have_http_status :ok
+  #     expect(response).to have_primary_data('users')
+  #     expect(response).to have_data_attributes(fields)
+  #     expect(response).to have_relationships(relationships)
+  #   end
+
+  #   context 'with "include"' do
+  #     it 'returns only the required relationships in the "included" member' do
+  #       get :index, params: { include: 'profile,posts' }
+  #       expect(response).to have_http_status :ok
+  #       expect(response).to have_primary_data('users')
+  #       expect(response).to have_data_attributes(fields)
+  #       expect(response).to have_relationships(relationships)
+  #       expect(response).to have_included_relationships
+  #     end
+  #   end
+
+  #   context 'with "fields"' do
+  #     it 'returns only the required fields in the "attributes" member' do
+  #       get :index, params: { fields: { users: :first_name } }
+  #       expect(response).to have_http_status :ok
+  #       expect(response).to have_primary_data('users')
+  #       expect(response).to have_data_attributes(%w(first_name))
+  #     end
+  #   end
+
+  #   context 'with "filter"' do
+  #     let(:first_name) { user.first_name }
+  #     let(:full_name)  { "#{user.first_name} #{user.last_name}" }
+
+  #     it 'returns only results corresponding to the applied filter' do
+  #       get :index, params: { filter: { first_name: first_name } }
+  #       expect(response).to have_http_status :ok
+  #       expect(response).to have_primary_data('users')
+  #       expect(response).to have_meta_record_count(1)
+  #       expect(data.dig(0, 'attributes', 'first_name')).to eq(first_name)
+  #     end
+
+  #     it 'returns only results corresponding to the applied custom filter' do
+  #       get :index, params: { filter: { full_name: full_name } }
+  #       expect(response).to have_http_status :ok
+  #       expect(response).to have_primary_data('users')
+  #       expect(response).to have_meta_record_count(1)
+  #       expect(data.dig(0, 'attributes', 'full_name')).to eq(full_name)
+  #     end
+
+  #     context 'when using "dasherized_key"' do
+  #       before do
+  #         JSONAPI.configuration.json_key_format = :dasherized_key
+  #       end
+
+  #       it 'returns only results corresponding to the applied filter' do
+  #         get :index, params: { filter: { 'first-name' => first_name } }
+  #         expect(response).to have_http_status :ok
+  #         expect(response).to have_primary_data('users')
+  #         expect(data.dig(0, 'attributes', 'first-name')).to eq(first_name)
+  #       end
+  #     end
+
+  #     context 'when using "camelized_key"' do
+  #       before do
+  #         JSONAPI.configuration.json_key_format = :camelized_key
+  #       end
+
+  #       it 'returns only results corresponding to the applied filter' do
+  #         get :index, params: { filter: { 'firstName' => first_name } }
+  #         expect(response).to have_http_status :ok
+  #         expect(response).to have_primary_data('users')
+  #         expect(data.dig(0, 'attributes', 'firstName')).to eq(first_name)
+  #       end
+  #     end
+  #   end
+
+  #   context 'with "page"' do
+  #     context 'when using "paged" paginator' do
+  #       before(:all) do
+  #         JSONAPI.configuration.default_paginator = :paged
+  #       end
+
+  #       context 'at the first page' do
+  #         it 'returns paginated results' do
+  #           get :index, params: { page: { number: 1, size: 2 } }
+
+  #           expect(response).to have_http_status :ok
+  #           expect(response).to have_primary_data('users')
+  #           expect(data.size).to eq(2)
+  #           expect(response).to have_meta_record_count(3)
+
+  #           expect(json.dig('meta', 'page_count')).to eq(2)
+  #           expect(json.dig('links', 'first')).to be_present
+  #           expect(json.dig('links', 'next')).to be_present
+  #           expect(json.dig('links', 'last')).to be_present
+  #         end
+  #       end
+
+  #       context 'at the middle' do
+  #         it 'returns paginated results' do
+  #           get :index, params: { page: { number: 2, size: 1 } }
+
+  #           expect(response).to have_http_status :ok
+  #           expect(response).to have_primary_data('users')
+  #           expect(data.size).to eq(1)
+  #           expect(response).to have_meta_record_count(User.count)
+
+  #           expect(json.dig('meta', 'page_count')).to eq(3)
+  #           expect(json.dig('links', 'first')).to be_present
+  #           expect(json.dig('links', 'prev')).to be_present
+  #           expect(json.dig('links', 'next')).to be_present
+  #           expect(json.dig('links', 'last')).to be_present
+  #         end
+  #       end
+
+  #       context 'at the last page' do
+  #         it 'returns paginated results' do
+  #           get :index, params: { page: { number: 3, size: 1 } }
+
+  #           expect(response).to have_http_status :ok
+  #           expect(response).to have_primary_data('users')
+  #           expect(data.size).to eq(1)
+  #           expect(response).to have_meta_record_count(User.count)
+
+  #           expect(json.dig('meta', 'page_count')).to eq(3)
+  #           expect(json.dig('links', 'first')).to be_present
+  #           expect(json.dig('links', 'prev')).to be_present
+  #           expect(json.dig('links', 'last')).to be_present
+  #         end
+  #       end
+
+
+  #       context 'when filtering with pagination' do
+  #         let(:count) { User.where(user.slice(:first_name, :last_name)).count }
+
+  #         it 'returns paginated results according to the given filter' do
+  #           get :index, params: { filter: { full_name: user.full_name }, page: { number: 1, size: 2 } }
+
+  #           expect(response).to have_http_status :ok
+  #           expect(response).to have_primary_data('users')
+  #           expect(data.size).to eq(1)
+  #           expect(response).to have_meta_record_count(count)
+
+  #           expect(json.dig('meta', 'page_count')).to eq(1)
+  #           expect(data.dig(0, 'attributes', 'full_name')).to eq(user.full_name)
+  #         end
+  #       end
+
+  #       context 'without "size"' do
+  #         it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
+  #           get :index, params: { page: { number: 1 } }
+  #           expect(response).to have_http_status :ok
+  #           expect(data.size).to be <= JSONAPI.configuration.default_page_size
+  #           expect(response).to have_meta_record_count(User.count)
+  #           expect(json.dig('meta', 'page_count')).to eq(1)
+  #         end
+  #       end
+  #     end
+
+  #     context 'when using "offset" paginator' do
+  #       before(:all) do
+  #         JSONAPI.configuration.default_paginator = :offset
+  #       end
+
+  #       context 'at the first page' do
+  #         it 'returns paginated results' do
+  #           get :index, params: { page: { offset: 0, limit: 2 } }
+
+  #           expect(response).to have_http_status :ok
+  #           expect(response).to have_primary_data('users')
+  #           expect(data.size).to eq(2)
+  #           expect(response).to have_meta_record_count(User.count)
+
+  #           expect(json.dig('meta', 'page_count')).to eq(2)
+  #           expect(json.dig('links', 'first')).to be_present
+  #           expect(json.dig('links', 'next')).to be_present
+  #           expect(json.dig('links', 'last')).to be_present
+  #         end
+  #       end
+
+  #       context 'at the middle' do
+  #         it 'returns paginated results' do
+  #           get :index, params: { page: { offset: 1, limit: 1 } }
+
+  #           expect(response).to have_http_status :ok
+  #           expect(response).to have_primary_data('users')
+  #           expect(data.size).to eq(1)
+  #           expect(response).to have_meta_record_count(User.count)
+
+  #           expect(json.dig('meta', 'page_count')).to eq(3)
+  #           expect(json.dig('links', 'first')).to be_present
+  #           expect(json.dig('links', 'prev')).to be_present
+  #           expect(json.dig('links', 'next')).to be_present
+  #           expect(json.dig('links', 'last')).to be_present
+  #         end
+  #       end
+
+  #       context 'at the last page' do
+  #         it 'returns the paginated results' do
+  #           get :index, params: { page: { offset: 2, limit: 1 } }
+
+  #           expect(response).to have_http_status :ok
+  #           expect(response).to have_primary_data('users')
+  #           expect(data.size).to eq(1)
+  #           expect(response).to have_meta_record_count(User.count)
+
+  #           expect(json.dig('meta', 'page_count')).to eq(3)
+  #           expect(json.dig('links', 'first')).to be_present
+  #           expect(json.dig('links', 'prev')).to be_present
+  #           expect(json.dig('links', 'last')).to be_present
+  #         end
+  #       end
+
+  #       context 'without "limit"' do
+  #         it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
+  #           get :index, params: { page: { offset: 1 } }
+  #           expect(response).to have_http_status :ok
+  #           expect(data.size).to be <= JSONAPI.configuration.default_page_size
+  #           expect(response).to have_meta_record_count(User.count)
+  #           expect(json.dig('meta', 'page_count')).to eq(1)
+  #         end
+  #       end
+  #     end
+
+  #     context 'when using custom global paginator' do
+  #       before(:all) do
+  #         JSONAPI.configuration.default_paginator = :custom_offset
+  #       end
+
+  #       context 'at the first page' do
+  #         it 'returns paginated results' do
+  #           get :index, params: { page: { offset: 0, limit: 2 } }
+
+  #           expect(response).to have_http_status :ok
+  #           expect(response).to have_primary_data('users')
+  #           expect(data.size).to eq(2)
+  #           expect(response).to have_meta_record_count(User.count)
+
+  #           expect(json.dig('meta', 'page_count')).to eq(2)
+  #           expect(json.dig('links', 'first')).to be_present
+  #           expect(json.dig('links', 'next')).to be_present
+  #           expect(json.dig('links', 'last')).to be_present
+  #         end
+  #       end
+
+  #       context 'at the middle' do
+  #         it 'returns paginated results' do
+  #           get :index, params: { page: { offset: 1, limit: 1 } }
+
+  #           expect(response).to have_http_status :ok
+  #           expect(response).to have_primary_data('users')
+  #           expect(data.size).to eq(1)
+  #           expect(response).to have_meta_record_count(User.count)
+
+  #           expect(json.dig('meta', 'page_count')).to eq(3)
+  #           expect(json.dig('links', 'first')).to be_present
+  #           expect(json.dig('links', 'prev')).to be_present
+  #           expect(json.dig('links', 'next')).to be_present
+  #           expect(json.dig('links', 'last')).to be_present
+  #         end
+  #       end
+
+  #       context 'at the last page' do
+  #         it 'returns the paginated results' do
+  #           get :index, params: { page: { offset: 2, limit: 1 } }
+
+  #           expect(response).to have_http_status :ok
+  #           expect(response).to have_primary_data('users')
+  #           expect(data.size).to eq(1)
+  #           expect(response).to have_meta_record_count(User.count)
+
+  #           expect(json.dig('meta', 'page_count')).to eq(3)
+  #           expect(json.dig('links', 'first')).to be_present
+  #           expect(json.dig('links', 'prev')).to be_present
+  #           expect(json.dig('links', 'last')).to be_present
+  #         end
+  #       end
+
+  #       context 'without "limit"' do
+  #         it 'returns the amount of results based on "JSONAPI.configuration.default_page_size"' do
+  #           get :index, params: { page: { offset: 1 } }
+  #           expect(response).to have_http_status :ok
+  #           expect(data.size).to be <= JSONAPI.configuration.default_page_size
+  #           expect(response).to have_meta_record_count(User.count)
+  #           expect(json.dig('meta', 'page_count')).to eq(1)
+  #         end
+  #       end
+  #     end
+  #   end
+
+  #   context 'with "sort"' do
+  #     context 'when asc' do
+  #       it 'returns sorted results' do
+  #         get :index, params: { sort: :first_name }
+
+  #         first_name1 = data.dig(0, 'attributes', 'first_name')
+  #         first_name2 = data.dig(1, 'attributes', 'first_name')
+
+  #         expect(response).to have_http_status :ok
+  #         expect(response).to have_primary_data('users')
+  #         expect(first_name1).to be <= first_name2
+  #       end
+  #     end
+
+  #     context 'when desc' do
+  #       it 'returns sorted results' do
+  #         get :index, params: { sort: '-first_name,-last_name' }
+
+  #         first_name_1, last_name_1 = data.dig(0, 'attributes').values_at('first_name', 'last_name')
+  #         first_name_2, last_name_2 = data.dig(1, 'attributes').values_at('first_name', 'last_name')
+  #         sorted = first_name_1 > first_name_2 || (first_name_1 == first_name_2 && last_name_1 >= last_name_2)
+
+  #         expect(response).to have_http_status :ok
+  #         expect(response).to have_primary_data('users')
+  #         expect(sorted).to be_truthy
+  #       end
+  #     end
+
+  #     context 'when using "dasherized_key"' do
+  #       before do
+  #         JSONAPI.configuration.json_key_format = :dasherized_key
+  #       end
+
+  #       it 'returns sorted results' do
+  #         get :index, params: { sort: 'first-name' }
+
+  #         first_name_1 = data.dig(0, 'attributes', 'first-name')
+  #         first_name_2 = data.dig(1, 'attributes', 'first-name')
+
+  #         expect(response).to have_http_status :ok
+  #         expect(response).to have_primary_data('users')
+  #         expect(first_name_1 < first_name_2).to be_truthy
+  #       end
+  #     end
+
+  #     context 'when using "camelized_key"' do
+  #       before do
+  #         JSONAPI.configuration.json_key_format = :camelized_key
+  #       end
+
+  #       it 'returns sorted results' do
+  #         get :index, params: { sort: 'firstName' }
+
+  #         first_name_1 = data.dig(0, 'attributes', 'firstName')
+  #         first_name_2 = data.dig(1, 'attributes', 'firstName')
+
+  #         expect(response).to have_http_status :ok
+  #         expect(response).to have_primary_data('users')
+  #         expect(first_name_1 < first_name_2).to be_truthy
+  #       end
+  #     end
+  #   end
+  # end
+
+  # describe '#show' do
+  #   it 'renders a single user' do
+  #     get :show, params: { id: user.id }
+  #     expect(response).to have_http_status :ok
+  #     expect(response).to have_primary_data('users')
+  #     expect(response).to have_data_attributes(fields)
+  #     expect(data.dig('attributes', 'first_name')).to eq("User##{user.id}")
+  #   end
+
+  #   context 'when resource was not found' do
+  #     it 'renders a 404 response' do
+  #       get :show, params: { id: 999 }
+  #       expect(response).to have_http_status :not_found
+  #       expect(error['title']).to eq('Record not found')
+  #       expect(error['code']).to eq('404')
+  #     end
+  #   end
+  # end
+
+  # describe '#create' do
+  #   it 'creates a new user' do
+  #     expect { post :create, params: user_params }.to change(User, :count).by(1)
+  #     expect(response).to have_http_status :created
+  #     expect(response).to have_primary_data('users')
+  #     expect(response).to have_data_attributes(fields)
+  #     expect(data.dig('attributes', 'first_name')).to eq(user_params.dig(:data, :attributes, :first_name))
+  #   end
+
+  #   shared_examples_for '400 response' do |hash|
+  #     before { user_params.dig(:data, :attributes).merge!(hash) }
+
+  #     it 'renders a 400 response' do
+  #       expect { post :create, params: user_params }.to change(User, :count).by(0)
+  #       expect(response).to have_http_status :bad_request
+  #       expect(error['title']).to eq('Param not allowed')
+  #       expect(error['code']).to eq('105')
+  #     end
+  #   end
+
+  #   context 'with a not permitted param' do
+  #     it_behaves_like '400 response', foo: 'bar'
+  #   end
+
+  #   context 'with a param not present in resource\'s attribute list' do
+  #     it_behaves_like '400 response', admin: true
+  #   end
+
+  #   context 'with validation error and no status code set' do
+  #     before { user_params.dig(:data, :attributes).merge!(first_name: nil, last_name: nil) }
+
+  #     it 'renders a 400 response by default' do
+  #       expect { post :create, params: user_params }.to change(User, :count).by(0)
+  #       expect(response).to have_http_status :bad_request
+
+  #       expect(errors.dig(0, 'id')).to eq('first_name')
+  #       expect(errors.dig(0, 'title')).to eq('can\'t be blank')
+  #       expect(errors.dig(0, 'detail')).to eq('First name can\'t be blank')
+  #       expect(errors.dig(0, 'code')).to eq('100')
+  #       expect(errors.dig(0, 'source')).to be_nil
+
+  #       expect(errors.dig(1, 'id')).to eq('last_name')
+  #       expect(errors.dig(1, 'title')).to eq('can\'t be blank')
+  #       expect(errors.dig(1, 'detail')).to eq('Last name can\'t be blank')
+  #       expect(errors.dig(1, 'code')).to eq('100')
+  #       expect(errors.dig(1, 'source')).to be_nil
+  #     end
+  #   end
+  # end
+
+  # describe '#update' do
+  #   let(:post) { user.posts.first }
+
+  #   let(:update_params) do
+  #     user_params.tap do |params|
+  #       params[:data][:id] = user.id
+  #       params[:data][:attributes][:first_name] = 'Yukihiro'
+  #       params[:data][:relationships] = relationship_params
+  #       params.merge!(id: user.id)
+  #     end
+  #   end
+
+  #   let(:relationship_params) do
+  #     { posts: { data: [{ id: post.id, type: 'posts' }] } }
+  #   end
+
+  #   it 'update an existing user' do
+  #     patch :update, params: update_params
+
+  #     expect(response).to have_http_status :ok
+  #     expect(response).to have_primary_data('users')
+  #     expect(response).to have_data_attributes(fields)
+  #     expect(data['attributes']['first_name']).to eq(user_params[:data][:attributes][:first_name])
+
+  #     expect(user.reload.posts.count).to eq(1)
+  #     expect(user.posts.first).to eq(post)
+  #   end
+
+  #   context 'when resource was not found' do
+  #     before { update_params[:data][:id] = 999 }
+
+  #     it 'renders a 404 response' do
+  #       patch :update, params: update_params.merge(id: 999)
+  #       expect(response).to have_http_status :not_found
+  #       expect(error['title']).to eq('Record not found')
+  #       expect(error['code']).to eq('404')
+  #     end
+  #   end
+
+  #   context 'when validation fails' do
+  #     before { update_params[:data][:attributes].merge!(first_name: nil, last_name: nil) }
+
+  #     it 'render a 422 response' do
+  #       patch :update, params: update_params
+  #       expect(response).to have_http_status :unprocessable_entity
+  #       expect(errors[0]['id']).to eq('my_custom_validation_error')
+  #       expect(errors[0]['title']).to eq('My custom error message')
+  #       expect(errors[0]['code']).to eq('125')
+  #       expect(errors[0]['source']).to be_nil
+  #     end
+  #   end
+  # end
+
+  # describe 'use of JSONAPI::Resources\' default actions' do
+  #   describe '#show_relationship' do
+  #     it 'renders the user\'s profile' do
+  #       get :show_relationship, params: { user_id: user.id, relationship: 'profile' }
+  #       expect(response).to have_http_status :ok
+  #       expect(response).to have_primary_data('profiles')
+  #     end
+  #   end
+  # end
 end

--- a/spec/features/page_count_spec.rb
+++ b/spec/features/page_count_spec.rb
@@ -35,7 +35,7 @@ describe PageCountTestController, type: :controller do
 
   before(:all) do
     TestApp.draw_page_count_test_routes
-    FactoryGirl.create_list(:user, 3, :with_posts)
+    FactoryBot.create_list(:user, 3, :with_posts)
   end
 
   describe 'page count with a paged paginator' do

--- a/spec/features/record_count_spec.rb
+++ b/spec/features/record_count_spec.rb
@@ -56,7 +56,7 @@ describe RecordCountTestController, type: :controller do
 
   before(:all) do
     TestApp.draw_record_count_test_routes
-    FactoryGirl.create_list(:user, 3, :with_posts)
+    FactoryBot.create_list(:user, 3, :with_posts)
   end
 
   describe 'explicit count' do

--- a/spec/jsonapi/utils/support/pagination_spec.rb
+++ b/spec/jsonapi/utils/support/pagination_spec.rb
@@ -6,7 +6,7 @@ describe JSONAPI::Utils::Support::Pagination do
   end
 
   before(:all) do
-    FactoryGirl.create_list(:user, 2)
+    FactoryBot.create_list(:user, 2)
   end
 
   let(:options) { {} }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
 require 'smart_rspec'
-require 'factory_girl'
+require 'factory_bot'
 require 'support/helpers'
 
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.include Helpers::ResponseParser
 
   config.define_derived_metadata do |meta|

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,6 +1,6 @@
-require 'factory_girl'
+require 'factory_bot'
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :category, class: Category do
     sequence(:title) { |n| "Title for Category #{n}" }
   end
@@ -12,8 +12,8 @@ FactoryGirl.define do
     sequence(:id) { |n| n }
     sequence(:title) { |n| "Title for Post #{n}" }
     sequence(:body) { |n| "Body for Post #{n}" }
-    content_type :article
-    hidden_field 'It\'s a hidden field!'
+    content_type { :article }
+    hidden_field { 'It\'s a hidden field!' }
   end
 
   factory :user, class: User do

--- a/spec/support/shared/jsonapi_errors.rb
+++ b/spec/support/shared/jsonapi_errors.rb
@@ -14,19 +14,13 @@ shared_examples_for 'JSON API invalid request' do
     context 'with "fields"' do
       context 'when resource does not exist' do
         it 'renders a 400 response' do
-          get :index, params: { fields: { foo: 'bar' } }
-          expect(response).to have_http_status :bad_request
-          expect(error['title']).to eq('Invalid resource')
-          expect(error['code']).to eq('101')
+          expect { get :index, params: { fields: { foo: 'bar' } } }.to raise_error(JSONAPI::Exceptions::InvalidResource)
         end
       end
 
       context 'when field does not exist' do
         it 'renders a 400 response' do
-          get :index, params: { fields: { users: 'bar' } }
-          expect(response).to have_http_status :bad_request
-          expect(error['title']).to eq('Invalid field')
-          expect(error['code']).to eq('104')
+          expect { get :index, params: { fields: { users: 'bar' } } }.to raise_error(JSONAPI::Exceptions::InvalidField)
         end
       end
     end
@@ -161,10 +155,7 @@ shared_examples_for 'JSON API invalid request' do
     context 'with "sort"' do
       context 'when sort criteria is invalid' do
         it 'renders a 400 response' do
-          get :index, params: { sort: 'foo' }
-          expect(response).to have_http_status :bad_request
-          expect(error['title']).to eq('Invalid sort criteria')
-          expect(error['code']).to eq('114')
+          expect { get :index, params: { sort: 'foo' } }.to raise_error(JSONAPI::Exceptions::InvalidSortCriteria)
         end
       end
     end


### PR DESCRIPTION
This is an interesting gem, but it is limited to a very old version of jsonapi-resources. I need to update it so we can use it with the new jsonapi-resources features.