### PR TITLE
Compatibility with jsonapi-resources@0.9.7

### DIFF
--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rails', ENV['RAILS_VERSION'] || '~> 5.1'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
   spec.add_development_dependency 'rspec-rails', '~> 3.1'
   spec.add_development_dependency 'factory_girl', '~> 4.8'
   spec.add_development_dependency 'smart_rspec', '~> 0.1.6'

--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.9.0'
+  spec.add_runtime_dependency 'jsonapi-resources', '0.9.6'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.9.6'
+  spec.add_runtime_dependency 'jsonapi-resources', '0.9.7'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.9.7'
+  spec.add_runtime_dependency 'jsonapi-resources', '0.9.8'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/jsonapi/utils/request.rb
+++ b/lib/jsonapi/utils/request.rb
@@ -6,6 +6,11 @@ module JSONAPI::Utils
     def jsonapi_request_handling
       setup_request
       check_request
+    rescue JSONAPI::Exceptions::InvalidResource,
+           JSONAPI::Exceptions::InvalidField,
+           JSONAPI::Exceptions::InvalidInclude,
+           JSONAPI::Exceptions::InvalidSortCriteria => err
+      jsonapi_render_errors(json: err)
     end
 
     # Instantiate the request object.

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -172,7 +172,7 @@ describe PostsController, type: :controller do
         expect(subject).to have_http_status :ok
         expect(subject).to have_primary_data('posts')
         expect(subject).to have_data_attributes(fields)
-        expect(subject).to have_relationships(relationships)
+        expect(json).to_not have_key('relationships')
         expect(data.dig('attributes', 'title')).to eq('Lorem ipsum')
       end
     end


### PR DESCRIPTION
Tests are passing.

So far it seems like the only breaking change was this: https://github.com/cerebris/jsonapi-resources/commit/970bc7922bc162fb36cb5e67f511a8b63b45024f

Closes #93 