### PR TITLE
Compatibility with jsonapi-resources@0.9.9

### DIFF
--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.9.8'
+  spec.add_runtime_dependency 'jsonapi-resources', '0.9.9'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -28,7 +28,7 @@ describe UsersController, type: :controller do
       expect(response).to have_http_status :ok
       expect(response).to have_primary_data('users')
       expect(response).to have_data_attributes(fields)
-      expect(response).to have_relationships(relationships)
+      expect(response).to have_relationships(relationships - ['profile'])
     end
 
     context 'with "include"' do


### PR DESCRIPTION
Previous upgrade was in #98 

Spec change reflects new JR behavior of not including relationship links in case its routes were not defined:

https://github.com/tiagopog/jsonapi-utils/blob/36c76019472b692295172a7945f40c8da9d85441/spec/test_app.rb#L61-L64

It does not call `jsonapi_related_resource :profile` within the block.