### PR TITLE
Relax jsonapi-resources dependency. Update the version.

### DIFF
--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.9.11'
+  spec.add_runtime_dependency 'jsonapi-resources', '~> 0.9.12'
 
   spec.add_development_dependency 'bundler', '~> 1.14', '>= 1.14'
   spec.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'

--- a/lib/jsonapi/utils/version.rb
+++ b/lib/jsonapi/utils/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Utils
-    VERSION = '0.7.3'.freeze
+    VERSION = '0.7.4'.freeze
   end
 end


### PR DESCRIPTION
Yet another pull request to switch to a newer version of `jsonapi-resources`. `0.10` introduced a lot of breaking changes so we're stuck with `0.9` for now but it's Rails 6.1 compatible which is what most people care about right now.

`0.9.11 -> 0.9.12` changes:

```
Adds support for Rails 6.1. Performance improvement for polymorphic resources

Fixes:
- Fix link builder on root engine
- Fix URI.unescape is obsolete warnings
- fix filtering by included resource. When using of custom filter verifier - context is missing
```

All specs are passing.