### PR TITLE
Depend upon latest jsonapi-resources v0.10.5

### DIFF
--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.9.11'
+  spec.add_runtime_dependency 'jsonapi-resources', '~> 0.10.5'
 
   spec.add_development_dependency 'bundler', '~> 1.14', '>= 1.14'
   spec.add_development_dependency 'rake', '~> 12.3', '>= 12.3.3'


### PR DESCRIPTION
Testing the gem we found that it is incompatible with Rails 6.1 because it depends on `jsonapi-resources` v0.9.11. It produces the following error when starting Rails:

```
$ rails g migration add_authentication_token_to_users "authentication_token:string{30}:uniq"
Traceback (most recent call last):
	19: from bin/rails:4:in `<main>'
	18: from bin/rails:4:in `require'
	17: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/commands.rb:18:in `<top (required)>'
	16: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/command.rb:48:in `invoke'
	15: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/command/base.rb:69:in `perform'
	14: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	13: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	12: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
	11: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/commands/generate/generate_command.rb:21:in `perform'
	10: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/command/actions.rb:14:in `require_application_and_environment!'
	 9: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/command/actions.rb:22:in `require_application!'
	 8: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/command/actions.rb:22:in `require'
	 7: from /home/oliver/prog/coditramuntana/base_app/config/application.rb:7:in `<top (required)>'
	 6: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler.rb:174:in `require'
	 5: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler/runtime.rb:58:in `require'
	 4: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler/runtime.rb:58:in `each'
	 3: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler/runtime.rb:69:in `block in require'
	 2: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler/runtime.rb:69:in `each'
	 1: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler/runtime.rb:74:in `block (2 levels) in require'
/home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler/runtime.rb:74:in `require': cannot load such file -- jsonapi-utils (LoadError)
	23: from bin/rails:4:in `<main>'
	22: from bin/rails:4:in `require'
	21: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/commands.rb:18:in `<top (required)>'
	20: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/command.rb:48:in `invoke'
	19: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/command/base.rb:69:in `perform'
	18: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor.rb:392:in `dispatch'
	17: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/invocation.rb:127:in `invoke_command'
	16: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/thor-1.1.0/lib/thor/command.rb:27:in `run'
	15: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/commands/generate/generate_command.rb:21:in `perform'
	14: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/command/actions.rb:14:in `require_application_and_environment!'
	13: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/command/actions.rb:22:in `require_application!'
	12: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/railties-6.1.4.1/lib/rails/command/actions.rb:22:in `require'
	11: from /home/oliver/prog/coditramuntana/base_app/config/application.rb:7:in `<top (required)>'
	10: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler.rb:174:in `require'
	 9: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler/runtime.rb:58:in `require'
	 8: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler/runtime.rb:58:in `each'
	 7: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler/runtime.rb:65:in `block in require'
	 6: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler/runtime.rb:88:in `rescue in block in require'
	 5: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/2.7.0/bundler/runtime.rb:88:in `require'
	 4: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/jsonapi-utils-0.7.3/lib/jsonapi/utils.rb:1:in `<top (required)>'
	 3: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/jsonapi-resources-0.9.11/lib/jsonapi-resources.rb:8:in `<top (required)>'
	 2: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/jsonapi-resources-0.9.11/lib/jsonapi/resource_controller_metal.rb:1:in `<top (required)>'
	 1: from /home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/jsonapi-resources-0.9.11/lib/jsonapi/resource_controller_metal.rb:2:in `<module:JSONAPI>'
/home/oliver/.rbenv/versions/2.7.4/lib/ruby/gems/2.7.0/gems/jsonapi-resources-0.9.11/lib/jsonapi/resource_controller_metal.rb:8:in `<class:ResourceControllerMetal>': uninitialized constant ActionController::ForceSSL (NameError)
```

Later versions of `jsonapi-resources` have fixes for this and other Rails 6.1 related problems. For example, see:

- https://github.com/cerebris/jsonapi-resources/pull/1346
- https://github.com/cerebris/jsonapi-resources/pull/1352 

This PR upgrades the dependecy on `jsonapi-resources` to v0.10.5.