### PR TITLE
Reduce the amount of redundant COUNT queries

### DIFF
--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -134,6 +134,12 @@ module JSONAPI
         # @api private
         def build_collection_result(object, options)
           records = build_collection(object, options)
+
+          unless options.key?(:count)
+            limit = page_params['size'].to_i.nonzero? || JSONAPI.configuration.default_page_size
+            options[:count] = records.size if records.size < limit
+          end
+
           result_options = result_options(object, options)
 
           if related_resource_operation?(options)


### PR DESCRIPTION
Hi!

Small proposal for reducing the amount of `COUNT` queries when the result set is full already. Kinda hits performance.

Currently, the paginator makes `COUNT` query for each request (unless the `:count` option provided by user).
On some big tables (millions records) with many filters it adds a lot to response time, as while the main result is limited by user defined limit params, like `page[:size]`, the `COUNT` queries are executed against the whole table.

And it tends to be redundant if the amount of records returned for a query is already less than limit specified (as there won't be any more pages).